### PR TITLE
docs: API docstrings for Swagger/OpenAPI documentation

### DIFF
--- a/monitor/app/api/health/router.py
+++ b/monitor/app/api/health/router.py
@@ -22,9 +22,23 @@ from app.status import Status
 router = APIRouter(prefix="/api/health", tags=["health"])
 
 
-@router.get("")
+@router.get("", summary="Health summary")
 def health_summary(view: str | None = None):
-    """Full health cache, or ?view=status for summary."""
+    """Aggregated health status for all monitored services.
+
+    Returns the full scheduler cache by default. Use ``?view=status`` for a
+    compact summary with per-service status and an overall roll-up.
+
+    Data comes from the background scheduler cache, not live queries, so
+    results may be up to one polling interval stale.
+
+    Args:
+        view: Set to ``"status"`` for a compact per-service summary.
+
+    Returns:
+        Full cache dict keyed by service name, or compact status dict when
+        ``view=status``.
+    """
     if view == "status":
         all_data = store.fetch_all()
         services = {}
@@ -47,15 +61,27 @@ def health_summary(view: str | None = None):
     return {"overall": worst.name, **all_data}
 
 
-@router.get("/containers")
+@router.get("/containers", summary="Container health")
 def containers():
-    """Health status for all FastTAK containers."""
+    """Health status for all FastTAK Docker Compose containers.
+
+    Returns:
+        List of container health entries with status and metadata.
+    """
     return get_all_container_health()
 
 
-@router.get("/resources")
+@router.get("/resources", summary="Container resource usage")
 def resources():
-    """CPU/memory stats for all running containers."""
+    """Live CPU and memory stats for all running containers.
+
+    Unlike most health endpoints, this fetches stats per-request via the
+    Docker API rather than reading from the scheduler cache. Expect higher
+    latency proportional to the number of running containers.
+
+    Returns:
+        List of resource-usage dicts (CPU %, memory bytes/limit) per container.
+    """
     results = []
     for name in discover_running_services():
         stats = get_container_stats(name)
@@ -64,43 +90,87 @@ def resources():
     return results
 
 
-@router.get("/certs")
+@router.get("/certs", summary="TAK certificate expiry")
 def certs():
-    """Certificate expiry status for all TAK certs."""
+    """Certificate expiry status for TAK infrastructure certs.
+
+    Reads .pem files from the TAK cert directory and reports days until
+    expiry. These are infrastructure/CA certs only — user and service-account
+    certs are managed through their respective APIs (#25).
+
+    Returns:
+        List of cert entries with name, expiry date, and days remaining.
+    """
     return get_cert_status()
 
 
-@router.get("/database")
+@router.get("/database", summary="CoT database size")
 def database():
-    """CoT database size and status."""
+    """CoT (Cursor on Target) database size and status.
+
+    Reports total and live row counts so operators can gauge database growth
+    and decide when maintenance (e.g., VACUUM) is warranted.
+
+    Returns:
+        Dict with total size, live size, and status.
+    """
     return get_cot_db_size()
 
 
-@router.get("/updates")
+@router.get("/updates", summary="Available updates")
 def updates():
-    """Check for available updates across stack components."""
+    """Check for available updates across stack components.
+
+    Returns:
+        Update availability info per component.
+    """
     return check_updates()
 
 
-@router.get("/disk")
+@router.get("/disk", summary="Disk usage")
 def disk():
-    """Disk usage for key mount points."""
+    """Disk usage for key mount points.
+
+    Returns:
+        List of mount-point entries with used/total bytes and percentage.
+    """
     return get_disk_usage()
 
 
-@router.get("/tls")
+@router.get("/tls", summary="TLS certificate expiry")
 def tls():
-    """TLS certificate expiry for Caddy-served endpoints."""
+    """TLS certificate expiry for Caddy-served endpoints.
+
+    Returns:
+        TLS status with expiry dates for each served domain.
+    """
     return get_tls_status()
 
 
-@router.get("/config")
+@router.get("/config", summary="Config drift detection")
 def config():
-    """Check if .env has changed since monitor startup."""
+    """Detect .env configuration drift since monitor startup.
+
+    Computes a SHA-256 hash of the current .env file and compares it to the
+    baseline captured at startup. A mismatch indicates someone edited .env
+    without restarting the monitor.
+
+    Returns:
+        Dict with drift status, current hash, and baseline hash.
+    """
     return check_config_drift()
 
 
-@router.get("/autovacuum")
+@router.get("/autovacuum", summary="Autovacuum health")
 def autovacuum():
-    """Autovacuum health — dead tuple ratios and last vacuum times."""
+    """Autovacuum health for the CoT database.
+
+    Reports dead-tuple ratios and last vacuum timestamps per table. High
+    dead-tuple ratios indicate autovacuum may be falling behind, which
+    degrades query performance.
+
+    Returns:
+        List of per-table entries with dead tuple count, ratio, and last
+        vacuum time.
+    """
     return get_autovacuum_health()

--- a/monitor/app/api/ops/router.py
+++ b/monitor/app/api/ops/router.py
@@ -26,8 +26,24 @@ def _validate_container(name: str):
 # ── Logs ────────────────────────────────────────────────────────────────
 
 
-@router.get("/service/{name}/logs")
+@router.get("/service/{name}/logs", summary="Service container logs")
 def svc_logs(name: str, tail: int = Query(default=200, ge=1, le=5000)):
+    """Fetch raw container logs for a known Compose service.
+
+    Only services discovered in the Compose project are allowed; unknown
+    names are rejected with 400 to prevent container enumeration.
+
+    Args:
+        name: Compose service name (e.g., ``takserver``, ``caddy``).
+        tail: Number of log lines to return (1-5000, default 200).
+
+    Returns:
+        Dict with service name and timestamped log text.
+
+    Raises:
+        HTTPException(400): If the service name is not in the Compose project.
+        HTTPException(404): If the container exists in Compose but is not running.
+    """
     _validate_container(name)
     container = find_container(name)
     if container is None:
@@ -42,8 +58,20 @@ def svc_logs(name: str, tail: int = Query(default=200, ge=1, le=5000)):
 # ── Database ────────────────────────────────────────────────────────────
 
 
-@router.post("/database/vacuum")
+@router.post("/database/vacuum", summary="VACUUM FULL the CoT database")
 def db_vacuum():
+    """Run VACUUM FULL on the CoT database to reclaim disk space.
+
+    **WARNING**: VACUUM FULL takes an exclusive lock on the database. All TAK
+    clients will lose connectivity for the duration of the operation. Only
+    run this during a planned maintenance window.
+
+    Returns:
+        Dict with success flag and reclaimed-space info.
+
+    Raises:
+        HTTPException(500): If the vacuum operation fails.
+    """
     result = vacuum_database()
     if not result.get("success", True):
         raise HTTPException(500, result.get("error", "Unknown error"))
@@ -53,8 +81,16 @@ def db_vacuum():
 # ── Alert Testing ────────────────────────────────────────────────────────────
 
 
-@router.post("/alerts/test-email")
+@router.post("/alerts/test-email", summary="Send test email alert")
 def test_email():
+    """Send a test alert email to the configured recipient.
+
+    Uses the SMTP settings from the monitor's .env configuration. If email
+    alerting is misconfigured, this will return ``success: false``.
+
+    Returns:
+        Dict with ``success`` boolean.
+    """
     ok = send_alert_email(
         "Test Alert",
         "This is a test alert from FastTAK Monitor."
@@ -63,7 +99,15 @@ def test_email():
     return {"success": ok}
 
 
-@router.post("/alerts/test-sms")
+@router.post("/alerts/test-sms", summary="Send test SMS alert")
 async def test_sms():
+    """Send a test SMS alert to the configured phone number.
+
+    Uses the SMS provider settings from the monitor's .env configuration.
+    If SMS alerting is misconfigured, this will return ``success: false``.
+
+    Returns:
+        Dict with ``success`` boolean.
+    """
     ok = await send_alert_sms("[FastTAK] Test alert. SMS alerting is working.")
     return {"success": ok}

--- a/monitor/app/api/service_accounts/router.py
+++ b/monitor/app/api/service_accounts/router.py
@@ -101,15 +101,51 @@ class UpdateServiceAccountRequest(BaseModel):
 # ── Endpoints ────────────────────────────────────────────────────
 
 
-@router.get("/api/service-accounts")
+@router.get("/api/service-accounts", summary="List service accounts")
 def list_service_accounts():
+    """List all service accounts (svc_ prefix users).
+
+    Only returns Authentik users whose username starts with ``svc_``.
+    Regular users and other hidden-prefix accounts are excluded.
+
+    Returns:
+        Dict with ``results`` list of service account objects.
+    """
     ak = _get_authentik()
     accounts = ak.list_users(search="svc_")
     return {"results": accounts}
 
 
-@router.post("/api/service-accounts", status_code=201)
+@router.post("/api/service-accounts", status_code=201, summary="Create service account")
 def create_service_account(body: CreateServiceAccountRequest):
+    """Create a new service account with a client certificate.
+
+    Two modes are supported:
+
+    - **data**: Receives TAK data via assigned groups. Groups are required and
+      must already exist.
+    - **admin**: Gets a TAK Server admin cert. Groups are forbidden.
+
+    The ``svc_`` prefix is auto-prepended to the name if not already present.
+    Certificate validity is 1-3650 days (defaults to 365 for data, 730 for
+    admin).
+
+    If certificate generation fails after the Authentik user is created, the
+    user is automatically rolled back (deactivated) to avoid orphaned accounts.
+
+    Args:
+        body: Service account creation parameters.
+
+    Returns:
+        Created account object with mode, validity_days, and cert_download_url.
+
+    Raises:
+        HTTPException(400): If required groups don't exist, or groups are
+            provided for admin mode.
+        HTTPException(500): If certificate generation or admin registration
+            fails (Authentik user is rolled back).
+        HTTPException(503): If Authentik is not configured.
+    """
     ak = _get_authentik()
 
     # Auto-prepend svc_ if not already present
@@ -181,8 +217,25 @@ def create_service_account(body: CreateServiceAccountRequest):
     }
 
 
-@router.patch("/api/service-accounts/{account_id}")
+@router.patch("/api/service-accounts/{account_id}", summary="Update service account")
 def update_service_account(account_id: int, body: UpdateServiceAccountRequest):
+    """Update a service account's display name or group membership.
+
+    Validation is atomic: all groups are checked for existence before any
+    changes are applied. If any group is missing, the entire request is
+    rejected without side effects.
+
+    Args:
+        account_id: Authentik user ID.
+        body: Fields to update (display_name, groups).
+
+    Returns:
+        ``{"success": true}`` on success.
+
+    Raises:
+        HTTPException(400): If any specified groups don't exist.
+        HTTPException(404): If account_id doesn't exist or isn't a svc_ account.
+    """
     ak = _get_authentik()
     user = ak.get_user(account_id)
     if not user:
@@ -208,8 +261,21 @@ def update_service_account(account_id: int, body: UpdateServiceAccountRequest):
     return {"success": True}
 
 
-@router.get("/api/service-accounts/{account_id}")
+@router.get("/api/service-accounts/{account_id}", summary="Get service account")
 def get_service_account(account_id: int):
+    """Get a single service account by ID.
+
+    Includes TAK Server certificate info when the TAK API is configured.
+
+    Args:
+        account_id: Authentik user ID.
+
+    Returns:
+        Service account object, optionally with ``certs`` list.
+
+    Raises:
+        HTTPException(404): If account_id doesn't exist or isn't a svc_ account.
+    """
     ak = _get_authentik()
     user = ak.get_user(account_id)
     if not user:
@@ -222,8 +288,22 @@ def get_service_account(account_id: int):
     return user
 
 
-@router.delete("/api/service-accounts/{account_id}")
+@router.delete("/api/service-accounts/{account_id}", summary="Delete service account")
 def delete_service_account(account_id: int):
+    """Deactivate a service account and revoke all its certificates.
+
+    This does **not** hard-delete the Authentik user — it deactivates it to
+    preserve the audit trail. All associated TAK Server certs are revoked.
+
+    Args:
+        account_id: Authentik user ID.
+
+    Returns:
+        ``{"success": true, "username": "..."}`` on success.
+
+    Raises:
+        HTTPException(404): If account_id doesn't exist or isn't a svc_ account.
+    """
     ak = _get_authentik()
     user = ak.get_user(account_id)
     if not user:
@@ -242,8 +322,25 @@ def delete_service_account(account_id: int):
     return {"success": True, "username": user["username"]}
 
 
-@router.get("/api/service-accounts/{account_id}/certs/download")
+@router.get("/api/service-accounts/{account_id}/certs/download", summary="Download service account cert")
 def download_cert(account_id: int):
+    """Download the .p12 certificate for a service account.
+
+    The .p12 password is always ``atakatak`` (DD-025). Revoked certificates
+    are blocked from download (DD-028) — the serial is checked against the
+    CRL before serving.
+
+    Args:
+        account_id: Authentik user ID.
+
+    Returns:
+        .p12 file as ``application/x-pkcs12`` download.
+
+    Raises:
+        HTTPException(403): If the certificate has been revoked.
+        HTTPException(404): If account not found, not a svc_ account, or
+            cert file missing.
+    """
     ak = _get_authentik()
     user = ak.get_user(account_id)
     if not user:

--- a/monitor/app/api/users/router.py
+++ b/monitor/app/api/users/router.py
@@ -107,13 +107,32 @@ class GenerateCertRequest(BaseModel):
 # ── User endpoints ────────────────────────────────────────────────
 
 
-@router.get("/api/users")
+@router.get("/api/users", summary="List users")
 def list_users(
     search: str | None = Query(default=None),
     include: str | None = Query(default=None),
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=50, ge=1, le=200),
 ):
+    """List human users with optional search and pagination.
+
+    Users with hidden prefixes (``svc_``, ``adm_``, ``ak-``, ``ma-``) are
+    automatically filtered out by the Authentik client. Pagination is
+    client-side: the full filtered list is fetched, then sliced.
+
+    Use ``include=certs`` to embed each user's certificate list (adds latency
+    from TAK Server API calls).
+
+    Args:
+        search: Filter usernames/names by substring.
+        include: Comma-separated includes. Currently only ``"certs"`` is
+            supported.
+        page: Page number (1-indexed).
+        page_size: Results per page (1-200, default 50).
+
+    Returns:
+        Paginated dict with ``results``, ``count``, ``page``, ``page_size``.
+    """
     ak = _get_authentik()
     users = ak.list_users(search=search)
 
@@ -130,8 +149,20 @@ def list_users(
     return {"results": page_users, "count": total, "page": page, "page_size": page_size}
 
 
-@router.post("/api/users", status_code=201)
+@router.post("/api/users", status_code=201, summary="Create user")
 def create_user(body: CreateUserRequest):
+    """Create a new TAK user in Authentik.
+
+    Users are passwordless by default — they enroll via the ``/enroll``
+    endpoint and connect with client certificates. An optional ``ttl_hours``
+    sets an auto-expiry so temporary users don't linger.
+
+    Args:
+        body: User creation parameters (username, name, ttl_hours, groups).
+
+    Returns:
+        Created user object.
+    """
     ak = _get_authentik()
     return ak.create_user(
         username=body.username,
@@ -141,8 +172,19 @@ def create_user(body: CreateUserRequest):
     )
 
 
-@router.get("/api/users/{user_id}")
+@router.get("/api/users/{user_id}", summary="Get user")
 def get_user(user_id: int):
+    """Get a single user by ID, including their TAK certificates.
+
+    Args:
+        user_id: Authentik user ID.
+
+    Returns:
+        User object with ``certs`` list when TAK Server is configured.
+
+    Raises:
+        HTTPException(404): If user_id doesn't exist.
+    """
     ak = _get_authentik()
     user = ak.get_user(user_id)
     if not user:
@@ -153,8 +195,26 @@ def get_user(user_id: int):
     return user
 
 
-@router.patch("/api/users/{user_id}")
+@router.patch("/api/users/{user_id}", summary="Update user")
 def update_user(user_id: int, body: UpdateUserRequest):
+    """Update user fields (name, is_active, ttl_hours).
+
+    TTL semantics: sending ``ttl_hours: null`` (JSON null) **clears** the TTL.
+    Omitting the field entirely leaves it unchanged. This distinction uses
+    Pydantic's ``model_fields_set`` to differentiate null from absent.
+
+    A deactivated user can be reactivated by setting ``is_active: true``.
+
+    Args:
+        user_id: Authentik user ID.
+        body: Fields to update (all optional).
+
+    Returns:
+        Updated user object.
+
+    Raises:
+        HTTPException(404): If user_id doesn't exist.
+    """
     ak = _get_authentik()
     user = ak.get_user(user_id)
     if not user:
@@ -173,8 +233,23 @@ def update_user(user_id: int, body: UpdateUserRequest):
     return ak.update_user(user_id, **kwargs)
 
 
-@router.delete("/api/users/{user_id}")
+@router.delete("/api/users/{user_id}", summary="Delete user")
 def delete_user(user_id: int):
+    """Deactivate a user and revoke all their certificates.
+
+    This does **not** hard-delete the Authentik user — it deactivates it to
+    preserve the audit trail. The user can be reactivated later via PATCH
+    with ``is_active: true``.
+
+    Args:
+        user_id: Authentik user ID.
+
+    Returns:
+        ``{"success": true, "username": "..."}`` on success.
+
+    Raises:
+        HTTPException(404): If user_id doesn't exist.
+    """
     ak = _get_authentik()
     user = ak.get_user(user_id)
     if not user:
@@ -191,8 +266,25 @@ def delete_user(user_id: int):
     return {"success": True, "username": user["username"]}
 
 
-@router.post("/api/users/{user_id}/password")
+@router.post("/api/users/{user_id}/password", summary="Set user password")
 def set_password(user_id: int, body: SetPasswordRequest):
+    """Set a password for a user.
+
+    Most TAK users do **not** need passwords — they authenticate via client
+    certificates. Passwords are only required for WebTAK browser access on
+    port 8446.
+
+    Args:
+        user_id: Authentik user ID.
+        body: Password to set (min 1 character).
+
+    Returns:
+        ``{"success": true}`` on success.
+
+    Raises:
+        HTTPException(400): If the user is deactivated.
+        HTTPException(404): If user_id doesn't exist.
+    """
     ak = _get_authentik()
     user = ak.get_user(user_id)
     if not user:
@@ -203,8 +295,25 @@ def set_password(user_id: int, body: SetPasswordRequest):
     return {"success": True}
 
 
-@router.post("/api/users/{user_id}/enroll")
+@router.post("/api/users/{user_id}/enroll", summary="Enroll user")
 def enroll_user(user_id: int):
+    """Generate a ``tak://`` enrollment URL for ATAK/iTAK provisioning.
+
+    The URL contains a 15-minute TTL app password token. If a valid token
+    already exists for this user, it is reused rather than creating a new one
+    (idempotent re-enrollment).
+
+    Args:
+        user_id: Authentik user ID.
+
+    Returns:
+        Dict with ``enrollment_url`` (tak:// format) and ``expires_at``
+        timestamp.
+
+    Raises:
+        HTTPException(400): If the user is deactivated.
+        HTTPException(404): If user_id doesn't exist.
+    """
     ak = _get_authentik()
     user = ak.get_user(user_id)
     if not user:
@@ -287,8 +396,27 @@ def _compute_cert_hash(pem_path: Path) -> str | None:
     return None
 
 
-@router.get("/api/users/{user_id}/certs")
+@router.get("/api/users/{user_id}/certs", summary="List user certificates")
 def list_user_certs(user_id: int):
+    """List all certificates for a user, merging on-disk and TAK Server data.
+
+    Builds a unified list by scanning on-disk .p12/.pem files and matching
+    them to TAK Server certadmin entries via SHA-256 hash. This catches both
+    API-generated certs (on-disk) and QR-enrolled certs (certadmin only).
+
+    Revocation status is checked against the CRL for on-disk certs and
+    against certadmin's ``revocation_date`` for server-side certs.
+
+    Args:
+        user_id: Authentik user ID.
+
+    Returns:
+        List of cert entries with ``name``, ``downloadable``, ``revoked``,
+        ``cert_id``, and ``expiration_date``.
+
+    Raises:
+        HTTPException(404): If user_id doesn't exist.
+    """
     ak = _get_authentik()
     user = ak.get_user(user_id)
     if not user:
@@ -368,8 +496,28 @@ def list_user_certs(user_id: int):
     return unified
 
 
-@router.post("/api/users/{user_id}/certs/generate", status_code=201)
+@router.post("/api/users/{user_id}/certs/generate", status_code=201, summary="Generate user certificate")
 def generate_user_cert(user_id: int, body: GenerateCertRequest):
+    """Generate a named client certificate for a user.
+
+    Creates ``{username}-{name}.p12`` with ``CN=username`` so all certs for a
+    user resolve to the same LDAP identity. Certificate validity is capped by
+    the user's ``fastak_expires`` if set — the cert will never outlive the user.
+
+    Args:
+        user_id: Authentik user ID.
+        body: Certificate name (alphanumeric, dots, hyphens, underscores).
+
+    Returns:
+        Dict with ``name``, ``filename``, ``validity_days``, and
+        ``download_url``.
+
+    Raises:
+        HTTPException(400): If the user is deactivated or already expired.
+        HTTPException(404): If user_id doesn't exist.
+        HTTPException(409): If a cert with the same name already exists.
+        HTTPException(500): If cert generation fails.
+    """
     from app.api.service_accounts.cert_gen import generate_client_cert
 
     ak = _get_authentik()
@@ -410,16 +558,32 @@ def generate_user_cert(user_id: int, body: GenerateCertRequest):
     }
 
 
-@router.post("/api/users/{user_id}/certs/revoke")
+@router.post("/api/users/{user_id}/certs/revoke", summary="Revoke user certificate")
 def revoke_user_cert(user_id: int, body: RevokeCertRequest):
     """Revoke a certificate and update the CRL so TAK Server rejects it.
 
-    Provide exactly one of cert_id or cert_name:
-    - cert_id: for QR-enrolled certs (fetches PEM from certadmin, revokes via CRL)
-    - cert_name: for API-generated certs (revokes via CRL using on-disk .pem)
+    Provide exactly one of ``cert_id`` or ``cert_name``:
 
-    Both paths update the CRL (actual TLS revocation) AND mark the cert as
-    revoked in certadmin if applicable.
+    - **cert_id**: For QR-enrolled certs. Fetches PEM from certadmin, revokes
+      via CRL, and marks revoked in certadmin.
+    - **cert_name**: For API-generated certs. Revokes via CRL using on-disk
+      .pem only (certadmin may not know about these).
+
+    Both paths delete enrollment tokens to prevent re-enrollment with cached
+    credentials.
+
+    Args:
+        user_id: Authentik user ID.
+        body: Exactly one of ``cert_id`` (int) or ``cert_name`` (str).
+
+    Returns:
+        ``{"success": true}`` on success.
+
+    Raises:
+        HTTPException(400): If neither or both of cert_id/cert_name provided.
+        HTTPException(404): If user or certificate not found.
+        HTTPException(500): If CRL revocation fails.
+        HTTPException(503): If TAK Server not configured (cert_id path).
     """
     ak = _get_authentik()
     user = ak.get_user(user_id)
@@ -470,8 +634,29 @@ def revoke_user_cert(user_id: int, body: RevokeCertRequest):
     raise HTTPException(400, "Provide either cert_id or cert_name")
 
 
-@router.get("/api/users/{user_id}/certs/download/{cert_name}")
+@router.get("/api/users/{user_id}/certs/download/{cert_name}", summary="Download user certificate")
 def download_user_cert(user_id: int, cert_name: str):
+    """Download a named .p12 certificate file for a user.
+
+    The ``cert_name`` is validated against an allowlist pattern to prevent
+    path traversal. Revoked certificates are blocked from download (DD-028)
+    by checking the serial against the CRL before serving.
+
+    The .p12 password is always ``atakatak`` (DD-025).
+
+    Args:
+        user_id: Authentik user ID.
+        cert_name: Certificate name (the ``{name}`` part of
+            ``{username}-{name}.p12``).
+
+    Returns:
+        .p12 file as ``application/x-pkcs12`` download.
+
+    Raises:
+        HTTPException(400): If cert_name contains invalid characters.
+        HTTPException(403): If the certificate has been revoked.
+        HTTPException(404): If user or certificate file not found.
+    """
     if not re.match(r"^[a-zA-Z0-9._-]+$", cert_name):
         raise HTTPException(400, "Invalid certificate name")
     ak = _get_authentik()
@@ -502,26 +687,64 @@ def download_user_cert(user_id: int, cert_name: str):
 # ── Group endpoints ───────────────────────────────────────────────
 
 
-@router.get("/api/groups")
+@router.get("/api/groups", summary="List groups")
 def list_groups():
+    """List all Authentik groups.
+
+    Groups with the ``tak_`` prefix are auto-managed by TAK Server
+    integration. ``ROLE_ADMIN`` is filtered out (DD-026).
+
+    Returns:
+        List of group objects.
+    """
     return _get_authentik().list_groups()
 
 
-@router.post("/api/groups", status_code=201)
+@router.post("/api/groups", status_code=201, summary="Create group")
 def create_group(body: CreateGroupRequest):
+    """Create a new Authentik group.
+
+    Args:
+        body: Group name.
+
+    Returns:
+        Created group object.
+    """
     return _get_authentik().create_group(body.name)
 
 
-@router.get("/api/groups/{group_id}")
+@router.get("/api/groups/{group_id}", summary="Get group")
 def get_group(group_id: str):
+    """Get a single group by ID.
+
+    Args:
+        group_id: Authentik group UUID.
+
+    Returns:
+        Group object.
+
+    Raises:
+        HTTPException(404): If group_id doesn't exist.
+    """
     group = _get_authentik().get_group(group_id)
     if not group:
         raise HTTPException(404, "Group not found")
     return group
 
 
-@router.delete("/api/groups/{group_id}")
+@router.delete("/api/groups/{group_id}", summary="Delete group")
 def delete_group(group_id: str):
+    """Delete an Authentik group.
+
+    Args:
+        group_id: Authentik group UUID.
+
+    Returns:
+        ``{"success": true}`` on success.
+
+    Raises:
+        HTTPException(404): If group_id doesn't exist.
+    """
     ak = _get_authentik()
     group = ak.get_group(group_id)
     if not group:
@@ -530,8 +753,24 @@ def delete_group(group_id: str):
     return {"success": True}
 
 
-@router.put("/api/users/{user_id}/groups")
+@router.put("/api/users/{user_id}/groups", summary="Set user groups")
 def set_user_groups(user_id: int, body: SetGroupsRequest):
+    """Replace a user's group memberships.
+
+    This is a full replacement, not a merge — groups not in the list are
+    removed. Groups with the ``tak_`` prefix are auto-managed by TAK Server
+    integration.
+
+    Args:
+        user_id: Authentik user ID.
+        body: List of group names to assign.
+
+    Returns:
+        ``{"success": true}`` on success.
+
+    Raises:
+        HTTPException(404): If user_id doesn't exist.
+    """
     ak = _get_authentik()
     user = ak.get_user(user_id)
     if not user:


### PR DESCRIPTION
## Summary

Google-style docstrings on all 38 route handlers across 4 router files. Shows in the auto-generated Swagger UI at `/api/docs`.

Each docstring includes behavioral caveats, design decision references (DD-025/026/028), and gotchas that aren't obvious from the endpoint signature alone.

## Changes

- `monitor/app/api/health/router.py` — 10 endpoints
- `monitor/app/api/ops/router.py` — 4 endpoints  
- `monitor/app/api/service_accounts/router.py` — 6 endpoints
- `monitor/app/api/users/router.py` — 18 endpoints

## Test plan

- [x] 264 unit tests passing
- [ ] Verify docstrings render correctly in Swagger UI at `/api/docs`