### PR TITLE
feat: expose TAK Server API port 8443

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,6 +114,7 @@ services:
         condition: service_healthy
     ports:
       - "8089:8089"
+      - "8443:8443"
       - "8446:8446"
     volumes:
       - *tak-mount

--- a/uv.lock
+++ b/uv.lock
@@ -292,7 +292,7 @@ wheels = [
 
 [[package]]
 name = "fastak-dev"
-version = "0.8.1"
+version = "0.9.0"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary
- Adds port 8443 mapping to tak-server in docker-compose.yml
- Required for CloudTAK and other external tools that use client cert auth for missions, data packages, and admin API operations

## Test plan
- [x] Restart stack with new port mapping
- [ ] Verify CloudTAK connects on 8443

🤖 Generated with [Claude Code](https://claude.com/claude-code)