### PR TITLE
feat: add PgBouncer for Authentik connection pooling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,10 +26,11 @@ x-logging: &default-logging
 x-tak-mount: &tak-mount ${TAK_HOST_PATH:-./tak}:/opt/tak
 
 x-authentik-env: &authentik-env
-  AUTHENTIK_POSTGRESQL__HOST: app-db
+  AUTHENTIK_POSTGRESQL__HOST: pgbouncer
   AUTHENTIK_POSTGRESQL__USER: fastak
   AUTHENTIK_POSTGRESQL__NAME: authentik
   AUTHENTIK_POSTGRESQL__PASSWORD: ${APP_DB_PASSWORD}
+  AUTHENTIK_POSTGRESQL__DISABLE_SERVER_SIDE_CURSORS: "true"
   AUTHENTIK_REDIS__HOST: redis
   AUTHENTIK_SECRET_KEY: ${AUTHENTIK_SECRET_KEY}
   AUTHENTIK_BOOTSTRAP_PASSWORD: ${AUTHENTIK_ADMIN_PASSWORD}
@@ -151,6 +152,34 @@ services:
       retries: 5
       start_period: 10s
 
+  # ── Connection Pooler (PgBouncer) ──────────────────────────────────────
+  # Authentik's worker opens hundreds of DB connections during startup,
+  # easily exceeding PostgreSQL's max_connections. PgBouncer multiplexes
+  # the server's connections down to a fixed pool. The worker bypasses
+  # PgBouncer because migrations use advisory locks that don't work in
+  # transaction-pool mode. See issue #31 for details.
+  pgbouncer:
+    image: edoburu/pgbouncer@sha256:85d1e38593617af1b5f7f285e97d407e56c29939683cc7cfe4c8f6dc19f1268b
+    restart: unless-stopped
+    logging: *default-logging
+    depends_on:
+      app-db:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgres://fastak:${APP_DB_PASSWORD}@app-db:5432/authentik
+      AUTH_TYPE: scram-sha-256
+      POOL_MODE: transaction
+      DEFAULT_POOL_SIZE: "20"
+      MAX_CLIENT_CONN: "500"
+      MIN_POOL_SIZE: "5"
+      LISTEN_PORT: "5432"
+      SERVER_TLS_SSLMODE: disable
+    healthcheck:
+      test: ["CMD", "pg_isready", "-h", "localhost", "-p", "5432"]
+      interval: 10s
+      retries: 5
+      start_period: 5s
+
   # ── Identity (Authentik SSO, LDAP, TAK Portal) ────────────────────────
   # Start order: redis → authentik-server/worker → init-identity → authentik-ldap → tak-portal
 
@@ -169,7 +198,7 @@ services:
     restart: unless-stopped
     logging: *default-logging
     depends_on:
-      app-db:
+      pgbouncer:
         condition: service_healthy
       redis:
         condition: service_healthy
@@ -191,8 +220,12 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    # Worker connects directly to app-db — advisory locks used during
+    # migrations don't work through PgBouncer's transaction pooling.
     environment:
       <<: *authentik-env
+      AUTHENTIK_POSTGRESQL__HOST: app-db
+      AUTHENTIK_POSTGRESQL__DISABLE_SERVER_SIDE_CURSORS: "false"
 
   init-identity:
     build: ./init-identity

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4,6 +4,26 @@ Significant architectural and design decisions, with reasoning. Newest first.
 
 ---
 
+### DD-030: PgBouncer for Authentik connection pooling
+
+**Decision:** Add PgBouncer between Authentik's server and `app-db` in transaction-pool mode. The worker bypasses PgBouncer and connects directly to `app-db`.
+
+**Context:** Authentik's Dramatiq worker creates hundreds of psycopg3 connection pools, exhausting PostgreSQL's `max_connections`. The Postgres tuning (`idle_session_timeout`, `max_connections=300`) mitigates but doesn't prevent the issue under load or with accumulated state.
+
+**Alternatives considered:**
+1. Postgres tuning only (current state) — fragile, doesn't cap concurrent connections
+2. PgBouncer for all Authentik services — failed: worker migrations use advisory locks incompatible with transaction pooling
+3. Replace Authentik entirely — too disruptive for a connection management issue
+
+**Consequences:**
+- One additional container (`pgbouncer`), ~10MB RAM
+- `authentik-server` connects to `pgbouncer` instead of `app-db`
+- `authentik-worker` environment overrides the shared anchor to connect directly to `app-db`
+- Server-side cursors disabled for Authentik server (required for transaction pooling)
+- Postgres tuning remains as defense-in-depth for the worker's direct connections
+
+---
+
 ## DD-029: Deploy Modes (direct / subdomain)
 
 **Date:** 2026-04-04

--- a/setup.sh
+++ b/setup.sh
@@ -102,6 +102,11 @@ else
           "$TARGET_DIR/tak/certs/files"/*.txt \
           "$TARGET_DIR/tak/certs/files"/*.attr 2>/dev/null
   fi
+  # Copy healthcheck script into tak/ so the bind mount has a real file
+  # before tak-server starts. Without this, Docker creates an empty
+  # placeholder that shadows the file bind mount.
+  cp "$SCRIPT_DIR/tak-server/healthcheck.sh" "$TARGET_DIR/tak/healthcheck.sh"
+  chmod +x "$TARGET_DIR/tak/healthcheck.sh"
   echo "  Done."
 fi
 


### PR DESCRIPTION
## Summary

Adds PgBouncer between Authentik's server and `app-db` to prevent database connection exhaustion ([#31](https://github.com/pounde/FastTAK/issues/31)). Builds on top of the deploy-modes work in PR #32.

- **PgBouncer** in transaction-pool mode: 20 real DB connections, accepts 500 client connections
- **Authentik server** connects through PgBouncer (`DISABLE_SERVER_SIDE_CURSORS: true`)
- **Authentik worker** bypasses PgBouncer (direct to `app-db`) — migrations use advisory locks incompatible with transaction pooling
- **Postgres tuning** stays as defense-in-depth for the worker's direct connections
- **`setup.sh`** copies `healthcheck.sh` into `tak/` to prevent Docker Desktop bind mount shadowing

### Verified

- Stack comes up healthy with 17 DB connections (was 200+ without PgBouncer)
- Zero "too many clients" errors
- Forward auth, LDAP, enrollment all working
- ATAK devices connecting and communicating
- Idempotent restart clean

### Decision record

DD-030 added to `docs/decisions.md`.

## Test plan

- [x] All services healthy
- [x] DB connections stable at ~17 (well under 300 limit)
- [x] PgBouncer logs show clean connection multiplexing
- [x] No DB exhaustion errors in Authentik server or worker logs
- [x] Forward auth login flow works
- [x] ATAK device enrollment and connectivity verified
- [x] Idempotent restart (down + up) clean

Partially addresses #31

> **Note:** This branch includes all deploy-modes commits from PR #32. Merge #32 first, then this PR will show only the PgBouncer + healthcheck changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)