### PR TITLE
feat: memory caps on every container (DD-034)

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,29 +322,30 @@ docker compose down -v && rm -rf tak/ .env
 
 ## Resource Limits
 
-FastTAK does not enforce resource limits — your hardware varies. Recommended starting points:
+### Memory
 
-| Service        | Recommended Memory | Notes                                          |
-| -------------- | ------------------ | ---------------------------------------------- |
-| `tak-server`   | 4-8 GB             | JVM heap; scales with connected clients        |
-| `tak-database` | 1-2 GB             | PostgreSQL shared_buffers                      |
-| `app-db`       | 1 GB               | PostgreSQL — shared by LLDAP and Node-RED      |
-| `lldap`        | 128 MB             | Lightweight Rust LDAP server                   |
-| `ldap-proxy`   | 128 MB             | Go binary — LDAP proxy + forward auth          |
-| `nodered`      | 512 MB             | Depends on installed nodes and flow complexity |
-| `mediamtx`     | 512 MB             | Scales with concurrent streams                 |
-| `caddy`        | 256 MB             | Reverse proxy                                  |
+Each service has a memory cap enforced in `docker-compose.yml` (via
+`deploy.resources.limits.memory`). Starting points below — if your
+deployment has larger needs, override per-service via a
+`docker-compose.override.yml`.
 
-To set limits, add `deploy.resources.limits` to a service in `docker-compose.yml`:
+| Service           | Cap    | Notes                                   |
+| ----------------- | ------ | --------------------------------------- |
+| `tak-server`      | 4 GB   | JVM heap; scales with connected clients |
+| `tak-database`    | 2 GB   | PostgreSQL on write-heavy CoT workload  |
+| `app-db`          | 1 GB   | PostgreSQL shared by LLDAP + Node-RED   |
+| `tak-portal`      | 512 MB | Node.js web UI                          |
+| `nodered`         | 512 MB | Node-RED runtime                        |
+| `monitor`         | 512 MB | FastAPI management API                  |
+| `mediamtx`        | 512 MB | Scales with concurrent streams          |
+| `lldap`           | 256 MB | Rust LDAP server                        |
+| `caddy`           | 256 MB | Reverse proxy                           |
+| `ldap-proxy`      | 128 MB | Go LDAP bind proxy                      |
+| `init-config`     | 128 MB | One-shot bash (exits after bootstrap)   |
+| `init-identity`   | 256 MB | One-shot Python                         |
+| `init-ldap-ready` | 64 MB  | One-shot LDAP bind probe                |
 
-```yaml
-tak-server:
-  # ... existing config ...
-  deploy:
-    resources:
-      limits:
-        memory: 4G
-```
+See DD-034 for rationale.
 
 ## Troubleshooting
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,10 @@ services:
     entrypoint: ["/start.sh"]
     restart: unless-stopped
     logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          memory: 2G
     environment:
       TAK_DB_PASSWORD: ${TAK_DB_PASSWORD}
       PG_AUTOVACUUM_SCALE_FACTOR: ${PG_AUTOVACUUM_SCALE_FACTOR:-}
@@ -71,6 +75,10 @@ services:
     build: ./init-config
     restart: "no"
     logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          memory: 128M
     depends_on:
       tak-database:
         condition: service_healthy
@@ -97,6 +105,10 @@ services:
     entrypoint: ["/start.sh"]
     restart: unless-stopped
     logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          memory: 4G
     depends_on:
       tak-database:
         condition: service_healthy
@@ -125,6 +137,10 @@ services:
     image: postgres:15-alpine
     restart: unless-stopped
     logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          memory: 1G
     entrypoint: ["/start.sh"]
     environment:
       POSTGRES_DB: lldap
@@ -146,6 +162,10 @@ services:
     image: lldap/lldap:${LLDAP_VERSION}
     restart: unless-stopped
     logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          memory: 256M
     depends_on:
       app-db:
         condition: service_healthy
@@ -167,6 +187,10 @@ services:
     build: ./ldap-proxy
     restart: unless-stopped
     logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          memory: 128M
     depends_on:
       lldap:
         condition: service_healthy
@@ -193,6 +217,10 @@ services:
         LLDAP_VERSION: ${LLDAP_VERSION}
     restart: "no"
     logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          memory: 256M
     depends_on:
       init-config:
         condition: service_completed_successfully
@@ -220,6 +248,10 @@ services:
     build: ./init-ldap-ready
     restart: "no"
     logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          memory: 64M
     depends_on:
       ldap-proxy:
         condition: service_healthy
@@ -232,6 +264,10 @@ services:
     build: https://github.com/AdventureSeeker423/TAK-Portal.git#${TAK_PORTAL_VERSION:-main}
     restart: unless-stopped
     logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          memory: 512M
     healthcheck:
       test: ["CMD", "node", "-e", "const h=require('http');h.get('http://localhost:3000',r=>{process.exit(r.statusCode<400?0:1)}).on('error',()=>process.exit(1))"]
       interval: 30s
@@ -253,6 +289,10 @@ services:
     image: caddy:2-alpine
     restart: unless-stopped
     logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          memory: 256M
     depends_on:
       init-config:
         condition: service_completed_successfully
@@ -268,6 +308,10 @@ services:
     image: bluenviron/mediamtx:${MEDIAMTX_VERSION}
     restart: unless-stopped
     logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          memory: 512M
     # No healthcheck — scratch-based image has no shell/tools.
     # Monitor checks via Docker API container status instead.
     volumes:
@@ -281,6 +325,10 @@ services:
     image: nodered/node-red:${NODERED_VERSION}
     restart: unless-stopped
     logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          memory: 512M
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:1880/"]
       interval: 30s
@@ -316,6 +364,10 @@ services:
         LLDAP_VERSION: ${LLDAP_VERSION}
     restart: unless-stopped
     logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          memory: 512M
     depends_on:
       tak-server:
         condition: service_healthy

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -25,6 +25,44 @@ The tradeoff is the loss of PostGIS on `app-db`. Stock FastTAK does not depend o
 
 ---
 
+## DD-034: Memory Caps on Every Container
+
+**Date:** 2026-04-18
+**Status:** Decided
+
+**Decision:** Every service in `docker-compose.yml` has `deploy.resources.limits.memory` set to a value that bounds its normal footprint with safety margin. Rule applies unconditionally — no `DEPLOY_MODE` branching.
+
+**Why:** Bounding memory caps the blast radius of any container failure: an OOM loop, a runaway process, or a DoS attack that tries to exhaust RAM on the host. Without caps, a single compromised or misbehaving container can starve the rest of the stack. The cost is low (a missized limit just causes OOM-kill of the offending container, which Docker's restart policy then handles) and the benefit is constant.
+
+**Starting values:**
+
+| Service         | Limit |
+|-----------------|-------|
+| tak-server      | 4G    |
+| tak-database    | 2G    |
+| app-db          | 1G    |
+| tak-portal      | 512M  |
+| nodered         | 512M  |
+| monitor         | 512M  |
+| mediamtx        | 512M  |
+| lldap           | 256M  |
+| caddy           | 256M  |
+| ldap-proxy      | 128M  |
+| init-config     | 128M  |
+| init-identity   | 256M  |
+| init-ldap-ready | 64M   |
+
+These were chosen based on observed idle/startup footprint plus safety margin, and validated via the integration test suite (81/81 tests pass under these caps). Operators with larger workloads (more concurrent clients, higher CoT volume) should override via `docker-compose.override.yml` rather than edit the base file.
+
+**Alternatives considered:**
+- CPU limits — deliberately deferred. Memory limits give most of the safety benefit without introducing latency surprises. CPU throttling under load can manifest as mysterious timeouts; better to add them only after observing CPU-starvation issues.
+- Swarm-only `deploy.*` syntax — not relevant; Compose v2 honors `deploy.resources.limits.memory` in non-Swarm mode since 2020.
+- No limits (status quo) — rejected, leaves the stack exposed to single-container memory exhaustion.
+
+**Related:** DD-033 (universal security defaults, same framing).
+
+---
+
 ## DD-033: Admin Password Generated Per-Install; Default Value Always Rejected
 
 **Date:** 2026-04-18

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4,7 +4,7 @@ Significant architectural and design decisions, with reasoning. Newest first.
 
 ---
 
-## DD-036: `app-db` Uses Official `postgres:15-alpine` Instead of `postgis/postgis`
+## DD-035: `app-db` Uses Official `postgres:15-alpine` Instead of `postgis/postgis`
 
 **Date:** 2026-04-18
 **Status:** Decided
@@ -37,7 +37,7 @@ The tradeoff is the loss of PostGIS on `app-db`. Stock FastTAK does not depend o
 **Starting values:**
 
 | Service         | Limit |
-|-----------------|-------|
+| --------------- | ----- |
 | tak-server      | 4G    |
 | tak-database    | 2G    |
 | app-db          | 1G    |
@@ -55,6 +55,7 @@ The tradeoff is the loss of PostGIS on `app-db`. Stock FastTAK does not depend o
 These were chosen based on observed idle/startup footprint plus safety margin, and validated via the integration test suite (81/81 tests pass under these caps). Operators with larger workloads (more concurrent clients, higher CoT volume) should override via `docker-compose.override.yml` rather than edit the base file.
 
 **Alternatives considered:**
+
 - CPU limits — deliberately deferred. Memory limits give most of the safety benefit without introducing latency surprises. CPU throttling under load can manifest as mysterious timeouts; better to add them only after observing CPU-starvation issues.
 - Swarm-only `deploy.*` syntax — not relevant; Compose v2 honors `deploy.resources.limits.memory` in non-Swarm mode since 2020.
 - No limits (status quo) — rejected, leaves the stack exposed to single-container memory exhaustion.


### PR DESCRIPTION
## Summary

Adds `deploy.resources.limits.memory` to every service in `docker-compose.yml` so any container OOM / runaway process / DoS attempt is bounded. Rule applies unconditionally in every `DEPLOY_MODE` — see DD-034.

CPU limits deliberately deferred (memory caps give most of the safety benefit without latency surprises).

## Stacked on PR #42

Base branch: `admin-password-enforcement` (PR #42). Will auto-rebase onto `main` once #42 merges.

## Values

| Service | Cap | | Service | Cap |
|---|---|---|---|---|
| tak-server | 4G | | caddy | 256M |
| tak-database | 2G | | ldap-proxy | 128M |
| app-db | 1G | | init-config | 128M |
| tak-portal | 512M | | init-identity | 256M |
| nodered | 512M | | init-ldap-ready | 64M |
| monitor | 512M | | | |
| mediamtx | 512M | | | |
| lldap | 256M | | | |

## Test Plan

- [x] `docker compose config` parses cleanly
- [x] Full stack comes up healthy with the new limits — all 13 services in `running`/`healthy` state within 40s
- [x] Integration test suite passes — **81/81 tests pass under the caps**
- [x] No OOM kills observed during smoke / integration run

## Files Changed

- `docker-compose.yml` — 52 lines added (4 per service × 13 services)
- `README.md` — memory section updated to reflect enforced caps
- `docs/decisions.md` — DD-034 added between DD-036 and DD-033