### PR TITLE
fix(ldap-proxy): rate limit counts only failed auth attempts (DD-037)

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -77,7 +77,20 @@ Only groups with the `tak_` prefix appear as TAK channels. Create groups in LLDA
 ## Rate Limiting
 
 Authentication requests to `/auth/verify` (the endpoint Caddy uses for
-forward_auth) are rate-limited per source IP. By default, 10 attempts
-per 5 minutes triggers a 15-minute lockout. Tunable via
-`LDAP_RATE_LIMIT_*` env vars (see `.env.example`). Exceeding the limit
-returns HTTP 429 with a `Retry-After` header. See DD-035.
+forward_auth) are rate-limited per source IP. Only **failed** attempts
+count toward the budget — successful auths don't consume it, because
+Caddy's forward_auth hits this endpoint on every protected-route
+request and counting successes would lock out legitimate users. See
+DD-037 for the failures-only semantics.
+
+By default, 10 failures per 5 minutes triggers a 15-minute lockout.
+Tunable via `LDAP_RATE_LIMIT_*` env vars (see `.env.example`).
+Exceeding the limit returns HTTP 429 with a `Retry-After` header.
+
+**Recovering from accidental lockout:** if you trip the limit during
+testing (wrong password, debugging client configs), restart
+`ldap-proxy` to clear the in-memory state:
+
+```bash
+docker compose restart ldap-proxy
+```

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4,6 +4,40 @@ Significant architectural and design decisions, with reasoning. Newest first.
 
 ---
 
+## DD-037: Rate Limit Counts Only Failed Auth Attempts
+
+**Date:** 2026-04-19
+**Status:** Decided (refines DD-036)
+
+**Decision:** The `/auth/verify` rate limiter counts **only failed** authentication attempts (401 responses). Successful auths do not consume the budget. The middleware's job is reduced to checking lockout state; the auth handler itself calls `RateLimiter.RecordFailure(ip)` on each 401 return.
+
+**Why:** Caddy's `forward_auth` hits `/auth/verify` on **every protected-route request**, not just logins. Counting every attempt — the original DD-036 implementation — meant a legitimate user clicking around the portal could trivially exceed the budget and lock themselves out. The original defaults of 10 attempts per 5 minutes were correct for a brute-force threat model but catastrophically tight for the actual per-request-forward-auth traffic pattern.
+
+Failures-only counting restores the intended semantics: brute-force attempts (which fail) are penalised; legitimate use (which succeeds) is not.
+
+**How it works:**
+- `Middleware` → calls `CheckLockout(ip)` only. Does not record anything. Returns 429 if the IP is currently locked out.
+- `HandleVerify` → on every 401 return path (missing header, bad credentials, invalid bind), calls `RecordFailure(ip)`.
+- `RecordFailure` → tracks per-IP failure timestamps in a sliding window; once the window-bounded failure count reaches `maxAttempts`, sets `lockoutUntil`.
+- `CheckLockout` → returns blocked if `now < lockoutUntil`, else allowed.
+
+**What does NOT count:**
+- 200 responses (successful auth)
+- 400 responses (malformed Basic auth header — user error, not credential guessing)
+- 500 responses (internal errors on the ldap-proxy side)
+- Any request that reaches the handler via a non-`/auth/verify` route
+
+**Lockout is not extended by continued retries:** once an attacker triggers lockout, their further attempts don't reset or extend the timer. The initial lockout duration is the penalty; they must stop or wait it out.
+
+**Alternatives considered:**
+- Count all attempts but raise the threshold (e.g., 1000/min) — rejected, makes brute-force protection largely theatrical. The right fix is semantic, not numeric.
+- Session-level caching at Caddy so forward_auth doesn't hit ldap-proxy every request — rejected as scope creep; would need a second cookie/session layer on top of forward_auth.
+- Count based on response code via a wrapped ResponseWriter in middleware — rejected, tighter coupling and harder to reason about. Explicit `RecordFailure` call from the handler is clearer.
+
+**Related:** DD-036 (the limiter this refines), DD-031 (ldap-proxy architecture).
+
+---
+
 ## DD-036: Rate Limit on LDAP `/auth/verify`
 
 **Date:** 2026-04-18

--- a/ldap-proxy/auth.go
+++ b/ldap-proxy/auth.go
@@ -11,11 +11,27 @@ import (
 )
 
 type AuthHandler struct {
-	proxy *LDAPProxy
+	proxy   *LDAPProxy
+	limiter *RateLimiter // optional; when non-nil, failed auths call RecordFailure
 }
 
-func NewAuthHandler(proxy *LDAPProxy) *AuthHandler {
-	return &AuthHandler{proxy: proxy}
+// NewAuthHandler creates a handler for /auth/verify.
+//
+// If limiter is non-nil, the handler calls limiter.RecordFailure on each 401
+// response so failures (and only failures) count toward the rate-limit budget.
+// Successful auths don't consume budget — important because Caddy's
+// forward_auth hits this endpoint on every protected request.
+func NewAuthHandler(proxy *LDAPProxy, limiter *RateLimiter) *AuthHandler {
+	return &AuthHandler{proxy: proxy, limiter: limiter}
+}
+
+// recordFailure records a failed auth against the rate limiter, if one is
+// configured. Called from every 401 return path in HandleVerify.
+func (a *AuthHandler) recordFailure(r *http.Request) {
+	if a.limiter == nil {
+		return
+	}
+	a.limiter.RecordFailure(clientIP(r))
 }
 
 // HandleVerify implements GET /auth/verify for Caddy forward_auth.
@@ -25,6 +41,7 @@ func (a *AuthHandler) HandleVerify(w http.ResponseWriter, r *http.Request) {
 	if authHeader == "" || !strings.HasPrefix(authHeader, "Basic ") {
 		w.Header().Set("WWW-Authenticate", `Basic realm="FastTAK"`)
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		a.recordFailure(r)
 		return
 	}
 
@@ -53,6 +70,7 @@ func (a *AuthHandler) HandleVerify(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		w.Header().Set("WWW-Authenticate", `Basic realm="FastTAK"`)
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		a.recordFailure(r)
 		return
 	}
 

--- a/ldap-proxy/main.go
+++ b/ldap-proxy/main.go
@@ -68,19 +68,21 @@ func main() {
 	// Initialize proxy
 	proxy := NewLDAPProxy(tokens, lldapAddr, baseDN, adminDN, adminPass)
 
-	// REST API
-	tokensAPI := NewTokensAPI(tokens, defaultTTL, defaultOneTime)
-	authHandler := NewAuthHandler(proxy)
-	healthHandler := NewHealthHandler(tokens, proxy)
-
 	// Rate limiter for /auth/verify — protects against brute force on LDAP auth.
-	// /tokens is internal-only (not Caddy-exposed). /healthz is Docker health probes.
-	// Defaults: 10 attempts per 5 minutes, 15-minute lockout. Configurable via env (DD-035).
+	// Only counts FAILED attempts (DD-037): Caddy's forward_auth hits this on every
+	// request, so counting successes would lock out legitimate users. /tokens is
+	// internal-only (not Caddy-exposed). /healthz is Docker health probes.
+	// Defaults: 10 failures per 5 minutes, 15-minute lockout. Configurable via env.
 	rateLimitWindow := envDurationOrDefault("LDAP_RATE_LIMIT_WINDOW", 5*time.Minute)
 	rateLimitLockout := envDurationOrDefault("LDAP_RATE_LIMIT_LOCKOUT", 15*time.Minute)
 	rateLimitMax := envIntOrDefault("LDAP_RATE_LIMIT_MAX_ATTEMPTS", 10)
-	log.Printf("rate limit: window=%s max=%d lockout=%s", rateLimitWindow, rateLimitMax, rateLimitLockout)
+	log.Printf("rate limit: window=%s max=%d lockout=%s (counting failures only)", rateLimitWindow, rateLimitMax, rateLimitLockout)
 	authRateLimit := NewRateLimiter(rateLimitWindow, rateLimitLockout, rateLimitMax, time.Now)
+
+	// REST API
+	tokensAPI := NewTokensAPI(tokens, defaultTTL, defaultOneTime)
+	authHandler := NewAuthHandler(proxy, authRateLimit)
+	healthHandler := NewHealthHandler(tokens, proxy)
 
 	// HTTP mux — no auth on these endpoints. The REST API is internal-only
 	// (not exposed via Caddy), reachable only from the Docker network by

--- a/ldap-proxy/ratelimit.go
+++ b/ldap-proxy/ratelimit.go
@@ -10,29 +10,34 @@ import (
 	"time"
 )
 
-// ipState tracks per-IP attempt history and any active lockout.
+// ipState tracks per-IP failure history and any active lockout.
 type ipState struct {
-	// attempts holds the timestamp of each recent attempt. Entries older than
-	// the window are pruned on every Check call, keeping memory bounded.
-	attempts []time.Time
+	// failures holds the timestamp of each recent *failed* auth attempt.
+	// Successful auths do not consume the budget. Entries older than the
+	// window are pruned on every interaction, keeping memory bounded.
+	failures []time.Time
 
-	// lockoutUntil is zero when the IP is not locked out. Once maxAttempts is
-	// reached, it is set to now+lockout and the IP is blocked until that time.
+	// lockoutUntil is zero when the IP is not locked out. Once maxAttempts
+	// failures accumulate within the window, it is set to now+lockout.
 	lockoutUntil time.Time
 }
 
-// RateLimiter is a per-IP sliding-window rate limiter with lockout support.
+// RateLimiter is a per-IP sliding-window failure-counting rate limiter with
+// lockout support.
 //
-// Design notes:
-//   - Sliding window (vs. fixed bucket): avoids the burst-at-bucket-boundary
-//     problem where an attacker can make 2×maxAttempts in a short span by
-//     timing requests to straddle two fixed windows.
-//   - In-memory state: ldap-proxy is a single-process, single-replica service.
-//     There is no need for distributed state (Redis etc.) at this scale, and
-//     keeping it in-process eliminates a runtime dependency.
-//   - Lockout distinct from window: after exceeding the attempt budget, the IP
-//     is locked out for a longer duration than the window, giving defenders
-//     time to react and penalising automated scanners more severely.
+// Design:
+//   - **Only failures count.** Legitimate users making lots of successful
+//     requests (e.g., Caddy's forward_auth, which hits /auth/verify on every
+//     protected-route request) do not consume budget. Only actual 401 returns
+//     from the auth handler count toward the lockout threshold.
+//   - Sliding window: avoids the burst-at-bucket-boundary problem where an
+//     attacker can make 2×maxAttempts in a short span by timing requests to
+//     straddle two fixed windows.
+//   - In-memory state: ldap-proxy is single-process, single-replica. No need
+//     for distributed state.
+//   - Lockout distinct from window: once maxAttempts failures accumulate, the
+//     IP is blocked for the longer lockout duration — gives defenders time to
+//     react and penalises automated scanners.
 type RateLimiter struct {
 	window      time.Duration
 	lockout     time.Duration
@@ -43,12 +48,12 @@ type RateLimiter struct {
 	state map[string]*ipState
 }
 
-// NewRateLimiter creates a limiter with the given window, lockout, max attempts,
+// NewRateLimiter creates a limiter with the given window, lockout, max failures,
 // and clock function.
 //
-//   - window:      period over which attempts are counted (e.g. 1 minute).
+//   - window:      period over which failures are counted (e.g. 5 minutes).
 //   - lockout:     how long an IP stays blocked after exceeding maxAttempts.
-//   - maxAttempts: number of attempts permitted within a window before blocking.
+//   - maxAttempts: number of failures permitted within a window before blocking.
 //   - clock:       time source; pass time.Now for production, a fake for tests.
 func NewRateLimiter(window, lockout time.Duration, maxAttempts int, clock func() time.Time) *RateLimiter {
 	return &RateLimiter{
@@ -60,15 +65,37 @@ func NewRateLimiter(window, lockout time.Duration, maxAttempts int, clock func()
 	}
 }
 
-// Check records an attempt from ip and reports whether it is permitted.
+// CheckLockout reports whether an IP is currently locked out. It does NOT
+// record anything — use RecordFailure to register a failed auth attempt.
 //
 // Returns:
-//   - allowed=true, retryAfter=0 when the attempt is within the budget.
-//   - allowed=false, retryAfter>0 when the IP is locked out; retryAfter is the
-//     remaining lockout duration.
+//   - allowed=true, retryAfter=0 when the IP is not locked out.
+//   - allowed=false, retryAfter>0 when the IP is locked out; retryAfter is
+//     the remaining lockout duration.
 //
 // Safe for concurrent use.
-func (rl *RateLimiter) Check(ip string) (allowed bool, retryAfter time.Duration) {
+func (rl *RateLimiter) CheckLockout(ip string) (allowed bool, retryAfter time.Duration) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	st, ok := rl.state[ip]
+	if !ok {
+		return true, 0
+	}
+
+	now := rl.clock()
+	if now.Before(st.lockoutUntil) {
+		return false, st.lockoutUntil.Sub(now)
+	}
+	return true, 0
+}
+
+// RecordFailure registers a failed authentication attempt from ip. If the
+// failure count within the sliding window reaches maxAttempts, the IP is
+// locked out for the configured lockout duration.
+//
+// Safe for concurrent use.
+func (rl *RateLimiter) RecordFailure(ip string) {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 
@@ -80,33 +107,31 @@ func (rl *RateLimiter) Check(ip string) (allowed bool, retryAfter time.Duration)
 		rl.state[ip] = st
 	}
 
-	// If the IP is currently locked out, report the remaining duration.
+	// If already locked out, don't extend — the existing lockout stands.
 	if now.Before(st.lockoutUntil) {
-		return false, st.lockoutUntil.Sub(now)
+		return
 	}
 
-	// Prune attempts that have aged out of the sliding window.
+	// Prune failures that have aged out of the sliding window.
 	cutoff := now.Add(-rl.window)
-	fresh := st.attempts[:0]
-	for _, ts := range st.attempts {
+	fresh := st.failures[:0]
+	for _, ts := range st.failures {
 		if ts.After(cutoff) {
 			fresh = append(fresh, ts)
 		}
 	}
-	st.attempts = fresh
+	st.failures = fresh
 
-	// Record the attempt.
-	st.attempts = append(st.attempts, now)
+	// Record the failure.
+	st.failures = append(st.failures, now)
 
-	// If the attempt count has reached the cap, apply lockout immediately.
-	// We set lockout on the attempt that fills the last slot so that subsequent
-	// checks (even after the window has rolled past the recorded attempts) still
-	// see the lockout. The attempt itself is allowed — the *next* one is blocked.
-	if len(st.attempts) >= rl.maxAttempts {
+	// If we've hit the threshold, apply lockout. We set lockout on the
+	// failure that fills the last slot so subsequent CheckLockout calls
+	// (even after the window has rolled past the recorded failures) still
+	// see the lockout.
+	if len(st.failures) >= rl.maxAttempts {
 		st.lockoutUntil = now.Add(rl.lockout)
 	}
-
-	return true, 0
 }
 
 // clientIP extracts the rate-limit key from a request.
@@ -128,14 +153,18 @@ func clientIP(r *http.Request) string {
 	return host
 }
 
-// Middleware wraps an http.Handler with rate-limit enforcement.
-// Source IP is taken from X-Forwarded-For (first entry) if present,
-// else from r.RemoteAddr (port stripped). On rate-limit, returns 429
-// with Retry-After set to seconds until the next permitted attempt.
+// Middleware wraps an http.Handler with lockout enforcement.
+//
+// The middleware ONLY checks whether the source IP is currently locked out —
+// it does not record failures. The wrapped handler is responsible for calling
+// RecordFailure when an auth attempt fails (e.g., 401 response).
+//
+// On lockout, returns 429 with Retry-After set to seconds until the next
+// permitted attempt.
 func (rl *RateLimiter) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ip := clientIP(r)
-		allowed, retryAfter := rl.Check(ip)
+		allowed, retryAfter := rl.CheckLockout(ip)
 		if !allowed {
 			secs := int(math.Ceil(retryAfter.Seconds()))
 			w.Header().Set("Retry-After", strconv.Itoa(secs))

--- a/ldap-proxy/ratelimit_test.go
+++ b/ldap-proxy/ratelimit_test.go
@@ -17,78 +17,88 @@ func advance(t *time.Time, d time.Duration) {
 	*t = t.Add(d)
 }
 
-func TestRateLimiter_UnderLimit_Allows(t *testing.T) {
+// ---------------------------------------------------------------------------
+// RateLimiter core (CheckLockout + RecordFailure)
+// ---------------------------------------------------------------------------
+
+func TestRateLimiter_FreshIP_NotLockedOut(t *testing.T) {
 	now := time.Unix(1_000_000, 0)
 	rl := NewRateLimiter(1*time.Minute, 5*time.Minute, 3, fakeClock(&now))
 
-	for i := 0; i < 2; i++ {
-		allowed, retryAfter := rl.Check("10.0.0.1")
-		if !allowed {
-			t.Fatalf("attempt %d (under limit): expected allowed, got blocked", i+1)
-		}
-		if retryAfter != 0 {
-			t.Fatalf("attempt %d: expected retryAfter=0, got %v", i+1, retryAfter)
-		}
+	allowed, retryAfter := rl.CheckLockout("10.0.0.1")
+	if !allowed {
+		t.Fatal("fresh IP: expected allowed, got blocked")
+	}
+	if retryAfter != 0 {
+		t.Fatalf("fresh IP: expected retryAfter=0, got %v", retryAfter)
 	}
 }
 
-func TestRateLimiter_AtLimit_Blocks(t *testing.T) {
+func TestRateLimiter_FailuresUnderLimit_NotLockedOut(t *testing.T) {
 	now := time.Unix(1_000_000, 0)
 	rl := NewRateLimiter(1*time.Minute, 5*time.Minute, 3, fakeClock(&now))
 
-	// Burn through the budget.
-	for i := 0; i < 3; i++ {
-		rl.Check("10.0.0.1")
-	}
+	// Record 2 failures — one short of the limit.
+	rl.RecordFailure("10.0.0.2")
+	rl.RecordFailure("10.0.0.2")
 
-	// The Nth attempt (4th, already over limit) should be blocked.
-	allowed, retryAfter := rl.Check("10.0.0.1")
-	if allowed {
-		t.Fatal("at/over limit: expected blocked, got allowed")
-	}
-	if retryAfter <= 0 {
-		t.Fatalf("expected positive retryAfter, got %v", retryAfter)
+	allowed, _ := rl.CheckLockout("10.0.0.2")
+	if !allowed {
+		t.Fatal("2 of 3 failures: expected still allowed, got blocked")
 	}
 }
 
-func TestRateLimiter_OverLimit_LockoutApplies(t *testing.T) {
+func TestRateLimiter_FailuresAtLimit_LockoutApplies(t *testing.T) {
 	now := time.Unix(1_000_000, 0)
 	lockout := 5 * time.Minute
 	rl := NewRateLimiter(1*time.Minute, lockout, 3, fakeClock(&now))
 
-	// Exhaust budget — the 3rd attempt triggers lockout.
+	// Fill the budget with failures.
 	for i := 0; i < 3; i++ {
-		rl.Check("10.0.0.2")
+		rl.RecordFailure("10.0.0.3")
 	}
 
-	// Advance time but stay inside the lockout window.
-	advance(&now, 2*time.Minute)
-	allowed, retryAfter := rl.Check("10.0.0.2")
+	allowed, retryAfter := rl.CheckLockout("10.0.0.3")
 	if allowed {
-		t.Fatal("inside lockout: expected blocked")
+		t.Fatal("after maxAttempts failures: expected blocked, got allowed")
 	}
-	// retryAfter should reflect remaining lockout (~3 min), not the full 5 min.
 	if retryAfter <= 0 || retryAfter > lockout {
-		t.Fatalf("unexpected retryAfter inside lockout: %v", retryAfter)
+		t.Fatalf("unexpected retryAfter: %v (lockout=%v)", retryAfter, lockout)
 	}
 }
 
-func TestRateLimiter_WindowRollover_Unblocks(t *testing.T) {
+func TestRateLimiter_SuccessesDontConsumeBudget(t *testing.T) {
+	// Regression test for the DD-037 fix: a legitimate user hitting
+	// /auth/verify 1000 times should not get locked out because only
+	// failures count toward the threshold. CheckLockout is a pure read.
+	now := time.Unix(1_000_000, 0)
+	rl := NewRateLimiter(1*time.Minute, 5*time.Minute, 3, fakeClock(&now))
+
+	for i := 0; i < 1000; i++ {
+		allowed, _ := rl.CheckLockout("10.0.0.4")
+		if !allowed {
+			t.Fatalf("after %d CheckLockout calls: expected allowed, got blocked", i+1)
+		}
+	}
+}
+
+func TestRateLimiter_WindowRollover_ClearsFailures(t *testing.T) {
 	now := time.Unix(1_000_000, 0)
 	window := 1 * time.Minute
 	rl := NewRateLimiter(window, 5*time.Minute, 3, fakeClock(&now))
 
-	// Make 2 attempts — one short of the limit.
-	rl.Check("10.0.0.3")
-	rl.Check("10.0.0.3")
+	// Two failures — one short of lockout.
+	rl.RecordFailure("10.0.0.5")
+	rl.RecordFailure("10.0.0.5")
 
-	// Roll the window forward so those attempts age out.
+	// Age those out of the window.
 	advance(&now, window+1*time.Second)
 
-	// Should be allowed again (slate wiped by window expiry).
-	allowed, _ := rl.Check("10.0.0.3")
+	// One more failure should NOT trigger lockout (pruned earlier ones).
+	rl.RecordFailure("10.0.0.5")
+	allowed, _ := rl.CheckLockout("10.0.0.5")
 	if !allowed {
-		t.Fatal("after window rollover: expected allowed, got blocked")
+		t.Fatal("after window rollover + 1 new failure: expected allowed")
 	}
 }
 
@@ -97,17 +107,16 @@ func TestRateLimiter_LockoutExpires_Unblocks(t *testing.T) {
 	lockout := 5 * time.Minute
 	rl := NewRateLimiter(1*time.Minute, lockout, 3, fakeClock(&now))
 
-	// Exhaust budget to trigger lockout.
+	// Trigger lockout.
 	for i := 0; i < 3; i++ {
-		rl.Check("10.0.0.4")
+		rl.RecordFailure("10.0.0.6")
 	}
 
-	// Advance past the lockout.
 	advance(&now, lockout+1*time.Second)
 
-	allowed, retryAfter := rl.Check("10.0.0.4")
+	allowed, retryAfter := rl.CheckLockout("10.0.0.6")
 	if !allowed {
-		t.Fatal("after lockout expiry: expected allowed, got blocked")
+		t.Fatal("after lockout expiry: expected allowed")
 	}
 	if retryAfter != 0 {
 		t.Fatalf("after lockout expiry: expected retryAfter=0, got %v", retryAfter)
@@ -118,132 +127,147 @@ func TestRateLimiter_PerIPIsolation(t *testing.T) {
 	now := time.Unix(1_000_000, 0)
 	rl := NewRateLimiter(1*time.Minute, 5*time.Minute, 3, fakeClock(&now))
 
-	// Exhaust budget for IP A.
+	// Lock out IP A.
 	for i := 0; i < 3; i++ {
-		rl.Check("10.0.0.5")
+		rl.RecordFailure("10.0.0.7")
 	}
 
-	// IP B should be completely unaffected.
-	allowed, retryAfter := rl.Check("10.0.0.6")
+	// IP B should be unaffected.
+	allowed, _ := rl.CheckLockout("10.0.0.8")
 	if !allowed {
-		t.Fatal("per-IP isolation: IP B should be allowed after IP A is blocked")
-	}
-	if retryAfter != 0 {
-		t.Fatalf("per-IP isolation: IP B retryAfter should be 0, got %v", retryAfter)
+		t.Fatal("per-IP isolation: IP B should be allowed when IP A is locked out")
 	}
 }
+
+func TestRateLimiter_AlreadyLockedOut_RecordFailureDoesntExtend(t *testing.T) {
+	// An already-locked-out IP that keeps retrying shouldn't have its lockout
+	// extended further — that would effectively create a permanent DoS with
+	// steady brute-force traffic. The initial lockout duration is the penalty.
+	now := time.Unix(1_000_000, 0)
+	lockout := 5 * time.Minute
+	rl := NewRateLimiter(1*time.Minute, lockout, 3, fakeClock(&now))
+
+	// Trigger lockout at t=0.
+	for i := 0; i < 3; i++ {
+		rl.RecordFailure("10.0.0.9")
+	}
+
+	// Attacker keeps hammering for 3 minutes.
+	for i := 0; i < 100; i++ {
+		advance(&now, 2*time.Second)
+		rl.RecordFailure("10.0.0.9")
+	}
+
+	// Advance past the ORIGINAL 5-minute lockout (with some slack for the
+	// 3 minutes we already advanced).
+	advance(&now, 3*time.Minute)
+
+	allowed, _ := rl.CheckLockout("10.0.0.9")
+	if !allowed {
+		t.Fatal("after original lockout elapsed: lockout should not have been extended by retries")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Middleware
+// ---------------------------------------------------------------------------
 
 // dummyHandler returns 200 OK and records how many times it was called.
 type dummyHandler struct{ calls int }
 
-func (h *dummyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (h *dummyHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	h.calls++
 	w.WriteHeader(http.StatusOK)
 }
 
-// TestMiddleware_Under_PassesThrough — N-1 requests from the same IP all
-// reach the inner handler with 200.
-func TestMiddleware_Under_PassesThrough(t *testing.T) {
+func TestMiddleware_SuccessfulRequests_DontLockOut(t *testing.T) {
+	// Regression test for DD-037. The middleware only checks lockout state;
+	// it does NOT record anything. A handler that always returns 200 should
+	// therefore never get its caller rate-limited.
 	now := time.Unix(1_000_000, 0)
-	maxAttempts := 5
-	rl := NewRateLimiter(1*time.Minute, 5*time.Minute, maxAttempts, fakeClock(&now))
+	rl := NewRateLimiter(1*time.Minute, 5*time.Minute, 3, fakeClock(&now))
 
 	inner := &dummyHandler{}
 	handler := rl.Middleware(inner)
 
-	for i := 0; i < maxAttempts-1; i++ {
+	// 100 successful requests from the same IP.
+	for i := 0; i < 100; i++ {
 		req := httptest.NewRequest("GET", "/auth/verify", nil)
-		req.RemoteAddr = "10.0.0.1:12345"
+		req.RemoteAddr = "10.0.0.10:12345"
 		rr := httptest.NewRecorder()
 		handler.ServeHTTP(rr, req)
 		if rr.Code != http.StatusOK {
-			t.Fatalf("request %d: expected 200, got %d", i+1, rr.Code)
+			t.Fatalf("request %d: expected 200, got %d (regression — successes shouldn't lock out)", i+1, rr.Code)
 		}
 	}
-	if inner.calls != maxAttempts-1 {
-		t.Fatalf("expected inner handler called %d times, got %d", maxAttempts-1, inner.calls)
+	if inner.calls != 100 {
+		t.Fatalf("expected 100 handler calls, got %d", inner.calls)
 	}
 }
 
-// TestMiddleware_AtLimit_Returns429 — after the budget-filling attempt, the
-// next request returns 429 with a Retry-After header.
-func TestMiddleware_AtLimit_Returns429(t *testing.T) {
+func TestMiddleware_LockedOutIP_Returns429(t *testing.T) {
 	now := time.Unix(1_000_000, 0)
-	maxAttempts := 3
-	rl := NewRateLimiter(1*time.Minute, 5*time.Minute, maxAttempts, fakeClock(&now))
+	rl := NewRateLimiter(1*time.Minute, 5*time.Minute, 3, fakeClock(&now))
 
-	handler := rl.Middleware(&dummyHandler{})
-
-	// Burn through the full budget (triggers lockout on last allowed request).
-	for i := 0; i < maxAttempts; i++ {
-		req := httptest.NewRequest("GET", "/auth/verify", nil)
-		req.RemoteAddr = "10.0.0.2:9999"
-		handler.ServeHTTP(httptest.NewRecorder(), req)
+	// Manually lock out an IP via direct RecordFailure calls.
+	for i := 0; i < 3; i++ {
+		rl.RecordFailure("10.0.0.11")
 	}
 
-	// The next request must be rejected.
+	inner := &dummyHandler{}
+	handler := rl.Middleware(inner)
+
 	req := httptest.NewRequest("GET", "/auth/verify", nil)
-	req.RemoteAddr = "10.0.0.2:9999"
+	req.RemoteAddr = "10.0.0.11:54321"
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusTooManyRequests {
-		t.Fatalf("expected 429, got %d", rr.Code)
+		t.Fatalf("locked-out IP: expected 429, got %d", rr.Code)
 	}
 	if rr.Header().Get("Retry-After") == "" {
-		t.Fatal("expected Retry-After header, got none")
+		t.Fatal("expected Retry-After header")
+	}
+	if inner.calls != 0 {
+		t.Fatalf("locked-out request should not reach handler, but handler was called %d times", inner.calls)
 	}
 }
 
-// TestMiddleware_XForwardedFor_UsedForKeying — when X-Forwarded-For is
-// present, the limiter keys on that IP, not on RemoteAddr.
-func TestMiddleware_XForwardedFor_UsedForKeying(t *testing.T) {
+func TestMiddleware_XForwardedFor_UsedForLockoutKey(t *testing.T) {
 	now := time.Unix(1_000_000, 0)
-	maxAttempts := 3
-	rl := NewRateLimiter(1*time.Minute, 5*time.Minute, maxAttempts, fakeClock(&now))
+	rl := NewRateLimiter(1*time.Minute, 5*time.Minute, 3, fakeClock(&now))
+
+	// Lock out via XFF "10.0.0.20".
+	for i := 0; i < 3; i++ {
+		rl.RecordFailure("10.0.0.20")
+	}
 
 	handler := rl.Middleware(&dummyHandler{})
 
-	// Exhaust budget keyed on X-Forwarded-For "10.0.0.5".
-	for i := 0; i < maxAttempts; i++ {
-		req := httptest.NewRequest("GET", "/auth/verify", nil)
-		req.RemoteAddr = "127.0.0.1:1111"
-		req.Header.Set("X-Forwarded-For", "10.0.0.5")
-		handler.ServeHTTP(httptest.NewRecorder(), req)
-	}
-
-	// Next request from the same X-Forwarded-For IP should be rate-limited.
 	req := httptest.NewRequest("GET", "/auth/verify", nil)
-	req.RemoteAddr = "127.0.0.1:2222" // different port, same XFF
-	req.Header.Set("X-Forwarded-For", "10.0.0.5")
+	req.RemoteAddr = "127.0.0.1:1111"
+	req.Header.Set("X-Forwarded-For", "10.0.0.20")
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusTooManyRequests {
-		t.Fatalf("expected 429 keyed on XFF IP, got %d", rr.Code)
+		t.Fatalf("expected 429 keyed on XFF, got %d", rr.Code)
 	}
 }
 
-// TestMiddleware_MultipleIPsInXForwardedFor_UsesFirst — when X-Forwarded-For
-// contains a comma-separated list, only the first entry is used.
 func TestMiddleware_MultipleIPsInXForwardedFor_UsesFirst(t *testing.T) {
 	now := time.Unix(1_000_000, 0)
-	maxAttempts := 3
-	rl := NewRateLimiter(1*time.Minute, 5*time.Minute, maxAttempts, fakeClock(&now))
+	rl := NewRateLimiter(1*time.Minute, 5*time.Minute, 3, fakeClock(&now))
+
+	// Lock out the first IP in a multi-value XFF.
+	for i := 0; i < 3; i++ {
+		rl.RecordFailure("1.2.3.4")
+	}
 
 	handler := rl.Middleware(&dummyHandler{})
 
-	// Exhaust budget using the first IP in a multi-value XFF header.
-	for i := 0; i < maxAttempts; i++ {
-		req := httptest.NewRequest("GET", "/auth/verify", nil)
-		req.RemoteAddr = "127.0.0.1:3333"
-		req.Header.Set("X-Forwarded-For", "1.2.3.4, 5.6.7.8")
-		handler.ServeHTTP(httptest.NewRecorder(), req)
-	}
-
-	// Next request keyed on "1.2.3.4" should be blocked.
 	req := httptest.NewRequest("GET", "/auth/verify", nil)
-	req.RemoteAddr = "127.0.0.1:4444"
+	req.RemoteAddr = "127.0.0.1:3333"
 	req.Header.Set("X-Forwarded-For", "1.2.3.4, 5.6.7.8")
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -252,37 +276,33 @@ func TestMiddleware_MultipleIPsInXForwardedFor_UsesFirst(t *testing.T) {
 		t.Fatalf("expected 429 for first XFF IP, got %d", rr.Code)
 	}
 
-	// A request arriving only from 5.6.7.8 should NOT be blocked (different key).
+	// Only the forwarding proxy (5.6.7.8) should not trigger lockout.
+	inner := &dummyHandler{}
+	handler2 := rl.Middleware(inner)
 	req2 := httptest.NewRequest("GET", "/auth/verify", nil)
 	req2.RemoteAddr = "127.0.0.1:5555"
 	req2.Header.Set("X-Forwarded-For", "5.6.7.8")
 	rr2 := httptest.NewRecorder()
-	handler.ServeHTTP(rr2, req2)
+	handler2.ServeHTTP(rr2, req2)
 
-	if rr2.Code == http.StatusTooManyRequests {
-		t.Fatal("5.6.7.8 should not be rate-limited — it was only a forwarding proxy")
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("5.6.7.8 should not be rate-limited, got %d", rr2.Code)
 	}
 }
 
-// TestMiddleware_NoXForwardedFor_FallsBackToRemoteAddr — without an XFF
-// header, the limiter falls back to RemoteAddr with the port stripped.
 func TestMiddleware_NoXForwardedFor_FallsBackToRemoteAddr(t *testing.T) {
 	now := time.Unix(1_000_000, 0)
-	maxAttempts := 3
-	rl := NewRateLimiter(1*time.Minute, 5*time.Minute, maxAttempts, fakeClock(&now))
+	rl := NewRateLimiter(1*time.Minute, 5*time.Minute, 3, fakeClock(&now))
+
+	// Lock out via the host part of a RemoteAddr.
+	for i := 0; i < 3; i++ {
+		rl.RecordFailure("192.168.1.1")
+	}
 
 	handler := rl.Middleware(&dummyHandler{})
 
-	// Exhaust budget via RemoteAddr (no XFF).
-	for i := 0; i < maxAttempts; i++ {
-		req := httptest.NewRequest("GET", "/auth/verify", nil)
-		req.RemoteAddr = "192.168.1.1:6666"
-		handler.ServeHTTP(httptest.NewRecorder(), req)
-	}
-
-	// Same host, different port — should still be blocked (port is stripped).
 	req := httptest.NewRequest("GET", "/auth/verify", nil)
-	req.RemoteAddr = "192.168.1.1:7777"
+	req.RemoteAddr = "192.168.1.1:7777" // same host, different port
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
@@ -291,22 +311,15 @@ func TestMiddleware_NoXForwardedFor_FallsBackToRemoteAddr(t *testing.T) {
 	}
 }
 
-// TestMiddleware_MalformedXForwardedFor_FallsBackToRemoteAddr — a garbage XFF
-// header value falls back to RemoteAddr.
 func TestMiddleware_MalformedXForwardedFor_FallsBackToRemoteAddr(t *testing.T) {
 	now := time.Unix(1_000_000, 0)
-	maxAttempts := 3
-	rl := NewRateLimiter(1*time.Minute, 5*time.Minute, maxAttempts, fakeClock(&now))
+	rl := NewRateLimiter(1*time.Minute, 5*time.Minute, 3, fakeClock(&now))
+
+	for i := 0; i < 3; i++ {
+		rl.RecordFailure("172.16.0.1")
+	}
 
 	handler := rl.Middleware(&dummyHandler{})
-
-	// Exhaust budget — malformed XFF should fall back to the RemoteAddr host.
-	for i := 0; i < maxAttempts; i++ {
-		req := httptest.NewRequest("GET", "/auth/verify", nil)
-		req.RemoteAddr = "172.16.0.1:8888"
-		req.Header.Set("X-Forwarded-For", "!!!not-an-ip!!!")
-		handler.ServeHTTP(httptest.NewRecorder(), req)
-	}
 
 	req := httptest.NewRequest("GET", "/auth/verify", nil)
 	req.RemoteAddr = "172.16.0.1:9999"

--- a/uv.lock
+++ b/uv.lock
@@ -292,7 +292,7 @@ wheels = [
 
 [[package]]
 name = "fastak-dev"
-version = "0.17.1"
+version = "0.20.0"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## The bug

DD-036 shipped a rate limiter that counted **every** \`/auth/verify\` request, regardless of outcome. But Caddy's \`forward_auth\` hits that endpoint on every protected-route request — not just login attempts. Default of 10 attempts per 5 minutes meant a legitimate user clicking around the portal trivially exceeded the budget and got locked out with a 429.

Discovered in production: user successfully deployed FastTAK to Lightsail, logged into the portal, and got rate-limited while trying to add a user.

## The fix

Counting semantic change: **only failed auth attempts consume budget.** Successful auths are free.

- \`RateLimiter.CheckLockout(ip)\` — pure read, returns whether IP is currently locked out
- \`RateLimiter.RecordFailure(ip)\` — call after a failed auth; records the failure and applies lockout when \`maxAttempts\` is reached
- \`Middleware\` calls \`CheckLockout\` only; never records anything
- \`AuthHandler.HandleVerify\` calls \`RecordFailure\` on every 401 return path

## Regression guard

Added \`TestMiddleware_SuccessfulRequests_DontLockOut\` — runs 100 successful requests from the same IP through the middleware. Under old semantics this would have triggered lockout after attempt 10. Under new semantics all 100 pass.

Also added \`TestRateLimiter_AlreadyLockedOut_RecordFailureDoesntExtend\` — ensures an attacker can't hold an IP in perpetual lockout by continuing to hammer after the initial block.

## What about the defaults?

Unchanged: 10 failures / 5 min window / 15 min lockout. **These were correct for a brute-force threat model; the implementation was wrong.** With failures-only counting, 10/5m is tight enough to stop credential guessing and loose enough not to bother legitimate users. Operators who tuned their \`.env\` to 60/1m/5m (the short-term workaround I told users to apply) should revert to the defaults once this PR lands.

## Test Plan

- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — 24 tests pass (new + updated tests)
- [x] \`just test\` — 377 unit tests pass
- [x] Integration test \`test_rate_limit.py\` semantics unchanged: 10 bad-auth probes → 401s → 11th → 429 (same observable behavior, just now driven by failure counting instead of total-call counting)

## Related

- Refines DD-036 (the original rate limit implementation)
- Related: DD-031 (ldap-proxy architecture)