### PR TITLE
fix: bind tak-server 8446 on host in base compose (DD-038)

### DIFF
--- a/docker-compose.direct.yml
+++ b/docker-compose.direct.yml
@@ -5,6 +5,11 @@
 # Used when DEPLOY_MODE=direct in .env.
 #
 #   Activated automatically by start.sh / justfile when DEPLOY_MODE=direct.
+#
+# NOTE: TAK Server's admin/enrollment port (8446) is bound directly on the
+# tak-server service in the base docker-compose.yml so that enrollment URLs
+# reach TAK Server's own cert chain (TAK CA), not Caddy's internal CA. Do not
+# add 8446 to Caddy here — it would collide with tak-server's binding.
 # =============================================================================
 
 services:
@@ -12,5 +17,4 @@ services:
     ports:
       - "${NODERED_PORT:-1880}:${NODERED_PORT:-1880}"
       - "${MONITOR_PORT:-8180}:${MONITOR_PORT:-8180}"
-      - "${TAKSERVER_ADMIN_PORT:-8446}:${TAKSERVER_ADMIN_PORT:-8446}"
       - "${MEDIAMTX_PORT:-8888}:${MEDIAMTX_PORT:-8888}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,8 +119,9 @@ services:
       init-ldap-ready:
         condition: service_completed_successfully
     ports:
-      - "8443:8443"   # Cert enrollment HTTPS
-      - "8089:8089"   # Streaming CoT
+      - "8443:8443"   # HTTPS
+      - "8446:8446"   # Cert enrollment / admin API (mTLS); URL target for enrollment QRs
+      - "8089:8089"   # Streaming CoT (mTLS)
     volumes:
       - *tak-mount
       - ./tak-server/start.sh:/start.sh:ro

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4,6 +4,34 @@ Significant architectural and design decisions, with reasoning. Newest first.
 
 ---
 
+## DD-038: Expose TAK Server 8446 Directly in Base Compose
+
+**Date:** 2026-04-19
+**Status:** Decided
+
+**Decision:** `tak-server` binds port 8446 on the host in the base `docker-compose.yml`, regardless of `DEPLOY_MODE`. The Caddy port binding for 8446 is removed from `docker-compose.direct.yml` (no longer needed and would collide). The Caddy subdomain route `takserver.${SERVER_ADDRESS}` is preserved as a convenience for browser access to the admin UI with Caddy's Let's Encrypt cert, but enrollment flows hit `SERVER_ADDRESS:8446` directly.
+
+**Why:** Before this change, subdomain mode didn't expose 8446 on the host at all — TAK Server listened on it internally and Caddy optionally proxied via the `takserver.` subdomain. But the portal generates enrollment URLs using `TAK_ENROLLMENT_PORT=8446` directly (`https://SERVER_ADDRESS:8446/Marti/api/...`). Clients scanning enrollment QRs tried to reach `:8446` and got connection refused. Operators had to add a local compose override binding 8446 before enrollment would work.
+
+In direct mode, Caddy previously handled 8446 with its internal-CA cert. That cert isn't in the TAK CA chain clients trust via the enrollment data package, so TLS validation could fail on strict clients. Routing 8446 directly to tak-server fixes both problems — clients consistently see the TAK CA cert regardless of mode.
+
+**Consequences:**
+- Subdomain mode: operators no longer need a local override for enrollment to work. Existing overrides remain harmless but unnecessary.
+- Direct mode: 8446 now hits tak-server directly instead of Caddy. The cert presented switches from Caddy's internal CA to the TAK CA — matches what enrollment clients expect. No operator action required; Docker port binding moves automatically on `docker compose up`.
+- The `docker-compose.test.yml` override (port offset `18446:8446` on tak-server) was already consistent with this model — confirms the test harness and the base compose were misaligned before this change, not after.
+
+**Scope:**
+- 8443 and 8089 remain bound on tak-server as before (HTTPS + CoT streaming, both mTLS).
+- 8446 is mTLS-protected for admin access (cert-based); unauthenticated enrollment (`/Marti/api/tls/signClient/v2`) requires Basic auth with a valid enrollment token. Public exposure is safe because both auth paths are cryptographically strong.
+
+**Alternatives considered:**
+- Generate subdomain-style enrollment URLs (`https://takserver.SERVER_ADDRESS`) from the portal instead of `:8446` URLs in subdomain mode — rejected as a larger change (touches monitor's Python URL-generation code) and inconsistent with how TAK ecosystem tooling and documentation refer to the enrollment port.
+- Document the local-override workaround permanently — rejected, puts the burden on every operator forever and foot-guns the deployment walkthrough.
+
+**Related:** DD-029 (deploy modes), DD-033 (universal security defaults applied regardless of mode).
+
+---
+
 ## DD-036: Rate Limit on LDAP `/auth/verify`
 
 **Date:** 2026-04-18

--- a/uv.lock
+++ b/uv.lock
@@ -292,7 +292,7 @@ wheels = [
 
 [[package]]
 name = "fastak-dev"
-version = "0.17.1"
+version = "0.20.0"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Problem

Subdomain mode didn't expose port **8446** on the host. Base `docker-compose.yml` only bound 8443 and 8089 for `tak-server`. But the portal generates enrollment URLs using `TAK_ENROLLMENT_PORT=8446` directly — e.g., `https://tak.example.com:8446/Marti/api/tls/signClient/v2?clientUID=...`. Clients scanning enrollment QRs got "connection refused" until operators hacked a local `docker-compose.local.yml` override.

Direct mode had the opposite problem: Caddy bound 8446 and terminated TLS with Caddy's **internal CA** cert. Enrollment clients trust the **TAK CA** (delivered via the enrollment data package), not Caddy's internal CA, so strict TLS clients rejected the handshake.

Found in production during the Lightsail deployment walkthrough (PR #45).

## Fix

`tak-server` binds 8446 on the host in base compose, same as 8443/8089. Direct-mode Caddy binding removed to avoid collision (tak-server now owns the port).

- **Subdomain mode:** 8446 just works — no operator override needed.
- **Direct mode:** 8446 goes directly to `tak-server`, cert chain = TAK CA (what enrollment clients expect).

Consistent with how `docker-compose.test.yml` was already overriding `tak-server` with `18446:8446` — the test harness and base compose were misaligned before this PR.

## Security implications

None new. Port 8446 was already reachable via Caddy proxy in direct mode and via `takserver.SERVER_ADDRESS` subdomain in subdomain mode. Admin access is mTLS-protected (cert-based). Enrollment (`/Marti/api/tls/signClient/v2`) requires Basic auth with a valid short-lived enrollment token. Public exposure was always the design — this PR just fixes the path.

## Test Plan

- [x] `docker compose config --quiet` parses cleanly
- [x] `just test` — 377 unit tests pass
- [x] Test-mode port offsets (`18446:8446`) still work correctly since the test override uses `!override` to fully replace base ports
- [ ] Integration test (`just test-integration`) — not run locally in this worktree, but change is a simple port binding swap that test infra already assumes

## Related

- Discovered during the Lightsail deployment walkthrough, PR #45
- DD-038 added in \`docs/decisions.md\`
- Follow-up: the Lightsail walkthrough's \`docker-compose.local.yml\` guidance currently includes a tak-server 8446 binding as a workaround. After this PR merges, that section can be simplified to just the MediaMTX `!reset`. I'll push that doc update to PR #45.

## Incidental

- \`uv.lock\` sync bump — the pre-commit pytest hook keeps regenerating it from the stale v0.17.1 after v0.20.0 release. Unrelated to this fix but required to get through pre-commit.