### PR TITLE
fix(security): gate admin APIs; fix silent TTL revocation (#52, #55)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -256,6 +256,11 @@ AUTOVACUUM_MIN_DEAD_TUPLES=1000
 # Keep the newest N backups; older ones are pruned after each successful run.
 # BACKUP_RETENTION_KEEP=14
 
+# LDAP group required to access the admin JSON APIs: /api/users/*,
+# /api/service-accounts/*, and /api/ops/* (user/cert management and destructive
+# DB operations). Callers not in this group get 403.
+# ADMIN_GROUP=monitor_admin
+
 # LDAP group required to access /api/backup/* and the dashboard backups page.
 # BACKUP_ADMIN_GROUP=monitor_admin
 

--- a/monitor/app/api/auth_deps.py
+++ b/monitor/app/api/auth_deps.py
@@ -37,3 +37,14 @@ def require_group(env_var: str, *, default: str) -> Callable[[Request], None]:
             )
 
     return _dep
+
+
+# Default admin group for the general admin APIs (users, service accounts, ops).
+# Kept equal to the backup default so a single group governs all admin surfaces
+# unless an operator splits them via the env vars.
+ADMIN_GROUP_DEFAULT = "monitor_admin"
+
+
+def require_admin() -> Callable[[Request], None]:
+    """Dependency gating a route on membership in the admin group (`ADMIN_GROUP`)."""
+    return require_group("ADMIN_GROUP", default=ADMIN_GROUP_DEFAULT)

--- a/monitor/app/main.py
+++ b/monitor/app/main.py
@@ -10,8 +10,9 @@ import logging
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 
+from app.api.auth_deps import require_admin
 from app.api.backup.router import router as backup_router
 from app.api.events.router import router as events_router
 from app.api.health.config_drift import init_config_hash
@@ -68,10 +69,15 @@ def _add_middleware_in_execution_order(app: FastAPI, *middlewares: type) -> None
 _add_middleware_in_execution_order(app, AuthContextMiddleware, AuditMiddleware)
 
 # API (JSON)
+# Admin-gated surfaces: users/service-accounts issue and revoke certs (privilege
+# escalation path) and ops runs destructive DB operations. Gated here at include
+# time so the whole router is protected regardless of per-route decorators.
+# backup_router carries its own require_group dependency internally.
+_admin = [Depends(require_admin())]
 app.include_router(health_router)
-app.include_router(ops_router)
-app.include_router(users_router)
-app.include_router(service_accounts_router)
+app.include_router(ops_router, dependencies=_admin)
+app.include_router(users_router, dependencies=_admin)
+app.include_router(service_accounts_router, dependencies=_admin)
 app.include_router(tak_router)
 app.include_router(events_router)
 app.include_router(backup_router)

--- a/monitor/app/scheduler.py
+++ b/monitor/app/scheduler.py
@@ -124,12 +124,18 @@ def _check_user_expiry(
                 ak.deactivate_user(user_id)
                 log.info("TTL expired: deactivated user %s (id=%d)", username, user_id)
 
-            if tak:
-                all_revoked = tak.revoke_all_user_certs(username)
-            else:
-                all_revoked = True
-
-            if all_revoked:
+            if tak is None:
+                # No TAK client configured: certs cannot be revoked. Do NOT mark
+                # the user revoked, or get_users_pending_expiry() would filter
+                # them out forever, leaving a valid cert on TAK Server. Leave the
+                # flag unset so a later tick retries once TAK is available (#55).
+                log.warning(
+                    "TTL expired: no TAK client available, deferring cert "
+                    "revocation for %s (id=%d)",
+                    username,
+                    user_id,
+                )
+            elif tak.revoke_all_user_certs(username):
                 ak.mark_certs_revoked(user_id)
                 log.info("TTL expired: revoked certs for %s (id=%d)", username, user_id)
             else:

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -16,5 +16,8 @@ def client():
     ):
         from app.main import app
 
-        with TestClient(app) as c:
+        # Default to an authenticated admin request. Admin-gated routers (issue
+        # #52) require a group; tests exercising rejection supply their own
+        # client/headers instead of using this fixture.
+        with TestClient(app, headers={"Remote-Groups": "monitor_admin"}) as c:
             yield c

--- a/tests/api/test_api_authorization.py
+++ b/tests/api/test_api_authorization.py
@@ -1,0 +1,56 @@
+"""Authorization gate for the admin JSON APIs (issue #52).
+
+The user, service-account, and ops routers must reject callers who are not in
+the admin group. Authentication (a valid LDAP bind) is handled upstream by
+Caddy `forward_auth` -> ldap-proxy, which sets `Remote-Groups`; these routers
+must additionally *authorize* on that group, mirroring the backup router.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    with (
+        patch("app.main.init_config_hash"),
+        patch("app.main.start_scheduler"),
+        patch("app.main.stop_scheduler"),
+    ):
+        from app.main import app
+
+        with TestClient(app) as c:
+            yield c
+
+
+NONADMIN = {"Remote-User": "bob", "Remote-Groups": "tak_alpha"}
+ADMIN = {"Remote-User": "alice", "Remote-Groups": "monitor_admin"}
+
+# (method, path) pairs that must be admin-gated. One representative route per router.
+GATED_ROUTES = [
+    ("get", "/api/users"),
+    ("post", "/api/service-accounts"),
+    ("post", "/api/ops/database/vacuum"),
+]
+
+
+@pytest.mark.parametrize("method,path", GATED_ROUTES)
+def test_rejects_missing_admin_group(client, method, path):
+    r = getattr(client, method)(path, headers=NONADMIN)
+    assert r.status_code == 403, f"{method} {path} was not gated (got {r.status_code})"
+
+
+@pytest.mark.parametrize("method,path", GATED_ROUTES)
+def test_rejects_no_groups_at_all(client, method, path):
+    r = getattr(client, method)(path)
+    assert r.status_code == 403, f"{method} {path} allowed an unauthenticated caller"
+
+
+@pytest.mark.parametrize("method,path", GATED_ROUTES)
+def test_admin_group_passes_the_gate(client, method, path):
+    """Admin must get *past* the auth gate (not 403). Downstream may 4xx/5xx on
+    unmocked dependencies — we only assert the gate itself does not reject."""
+    r = getattr(client, method)(path, headers=ADMIN)
+    assert r.status_code != 403, f"{method} {path} rejected a legitimate admin"

--- a/tests/unit/test_service_account_router.py
+++ b/tests/unit/test_service_account_router.py
@@ -6,7 +6,8 @@ import pytest
 from app.main import app
 from fastapi.testclient import TestClient
 
-client = TestClient(app)
+# service_accounts_router is admin-gated (issue #52); send an admin group on every request.
+client = TestClient(app, headers={"Remote-Groups": "monitor_admin"})
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_ttl_task.py
+++ b/tests/unit/test_ttl_task.py
@@ -113,6 +113,34 @@ class TestTtlEnforcement:
         mock_tak.revoke_all_user_certs.assert_called_with("ok_user")
         mock_ak.mark_certs_revoked.assert_called_once_with(5)
 
+    def test_defers_revocation_when_tak_unavailable(self):
+        """When no TAK client is configured, certs cannot be revoked — the user
+        must NOT be marked revoked, so a later tick retries once TAK is available
+        (issue #55). The account is still deactivated in LLDAP."""
+        from unittest.mock import patch
+
+        from app.scheduler import _check_user_expiry
+
+        mock_ak = MagicMock()
+        mock_ak.get_users_pending_expiry.return_value = [
+            {
+                "id": 6,
+                "username": "orphan",
+                "is_active": True,
+                "attributes": {
+                    "fastak_expires": int(time.time()) - 60,
+                    "fastak_certs_revoked": False,
+                },
+            },
+        ]
+
+        # tak=None arg makes the function resolve the scheduler singleton; force it None.
+        with patch("app.scheduler._get_scheduler_tak", return_value=None):
+            _check_user_expiry(mock_ak, None)
+
+        mock_ak.deactivate_user.assert_called_once_with(6)
+        mock_ak.mark_certs_revoked.assert_not_called()
+
     def test_noop_when_no_expired_users(self):
         from app.scheduler import _check_user_expiry
 

--- a/tests/unit/test_user_router.py
+++ b/tests/unit/test_user_router.py
@@ -7,7 +7,8 @@ import pytest
 from app.main import app
 from fastapi.testclient import TestClient
 
-client = TestClient(app)
+# users_router is admin-gated (issue #52); send an admin group on every request.
+client = TestClient(app, headers={"Remote-Groups": "monitor_admin"})
 
 
 def _make_test_ca_pem() -> bytes:


### PR DESCRIPTION
## What & why

Closes #52 (and #55).

The user, service-account, and ops JSON APIs enforced **no authorization**. The ldap-proxy authenticates any valid LDAP bind but does not authorize, and the app added no route-level group check — so any password-holding user (e.g. someone given only a WebTAK map password) could manage users, issue/download/revoke certs (including minting a **TAK ROLE_ADMIN** cert), and run `VACUUM FULL`.

- Gates `users_router`, `service_accounts_router`, and `ops_router` with a shared `require_admin` dependency (`ADMIN_GROUP`, default `monitor_admin`) at include time in `main.py`, mirroring the already-gated backup router.
- **#55:** the TTL scheduler no longer marks certs "revoked" when no TAK client is configured (it previously set `all_revoked=True` and marked done without revoking, leaving the cert valid on TAK Server forever). It now defers so a later tick retries.

Read-only `tak`/`events` feeds and the HTML dashboard routes are intentionally left ungated here (broader UX decision) — tracked as follow-up.

## Automated tests
- `tests/api/test_api_authorization.py` (new): non-admin and unauthenticated callers get 403 on `/api/users`, `/api/service-accounts`, `/api/ops/database/vacuum`; admins pass.
- `tests/unit/test_ttl_task.py`: added deferral test for the no-TAK-client path.
- Full suite: **551 passed**.

## Manual testing requirements (before merge)
Run against a real stack (`just dev-up`), authenticating through Caddy → ldap-proxy:

- [ ] As a **non-admin** user (in a `tak_*` group but **not** `monitor_admin`), confirm `GET /api/users`, `POST /api/service-accounts`, and `POST /api/ops/database/vacuum` all return **403**.
- [ ] As an **admin** (in `monitor_admin`), confirm the dashboard still loads and user/service-account/ops actions work end-to-end (list users, create a data service account + download cert, run a DB vacuum).
- [ ] Confirm the **backups** page/API still works for an admin (regression check — it was already gated).
- [ ] Set `ADMIN_GROUP` to a custom group name in `.env`, restart monitor, and confirm the gate follows the new group (membership in the new group passes; `monitor_admin` no longer does).
- [ ] **#55:** with `TAK_API_CERT_PATH` unset/misconfigured, create a TTL user, let it expire, and confirm the scheduler logs "deferring cert revocation" and does **not** mark the user revoked (so it's reprocessed once the TAK client is restored). With a healthy TAK client, confirm expiry revokes as before.

## Notes
- `ADMIN_GROUP` documented in `.env.example`. Existing deploys inherit the default `monitor_admin`, so no config change is required unless you split admin groups.
